### PR TITLE
Typo in spead2.recv.Stream.add_udp_reader doc

### DIFF
--- a/doc/py-recv.rst
+++ b/doc/py-recv.rst
@@ -58,7 +58,7 @@ or repeatedly call :py:meth:`~spead2.recv.Stream.get`.
 
       Feed data from an object implementing the buffer protocol.
 
-   .. py:method:: add_udp_reader(port, max_size=9200, buffer_size=8388608, bind_host_name='', socket=None)
+   .. py:method:: add_udp_reader(port, max_size=9200, buffer_size=8388608, bind_hostname='', socket=None)
 
       Feed data from a UDP port.
 


### PR DESCRIPTION
Argument is bind_hostname, not bind_host_name
Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>