### PR TITLE
Remove unneeded line from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 global-include Makefile.in
 global-include aclocal.m4
-global-include *asyncio.py
 exclude src/common_features.h
 exclude .gitignore
 include configure


### PR DESCRIPTION
It dates from when the *asyncio.py files were generated, but they're now
checked in to git and thus picked up by setuptools_git.