### PR TITLE
Fix a race condition in TCP accept_handler

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+.. rubric:: Development version
+
+- Fix race condition in TCP receiver (#78)
+
 .. rubric:: 2.0.0
 
 - Drop support for Python 2.

--- a/src/recv_tcp.cpp
+++ b/src/recv_tcp.cpp
@@ -216,6 +216,13 @@ bool tcp_reader::skip_bytes()
 
 void tcp_reader::accept_handler(const boost::system::error_code &error)
 {
+    /* We need to hold the stream's queue_mutex, because that guards access
+     * to the sockets. This is a heavy-weight way to do it, but since it
+     * only happens once per connection it is probably not worth trying to
+     * add a lighter-weight interface to @c stream.
+     */
+    stream_base::add_packet_state state(get_stream_base());
+
     acceptor.close();
     if (!error)
         enqueue_receive();


### PR DESCRIPTION
It was manipulating the sockets without the appropriate mutex. Apart
from generally being undefined behaviour, it could manifest as trying to
double-close the socket leading to an EBADF exception, killing the
io_service thread.

Closes #78.