### PR TITLE
When a completion channel is ready, consume all events from it.

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,6 +5,8 @@ Changelog
 
 - Add missing ``<map>`` include to ``<spead2/recv_heap.h>``.
 - Show the values of immediate items in :program:`spead2_recv`.
+- Fix occasional crash when using thread pool with more than one thread
+  together with ibverbs.
 
 .. rubric:: 2.0.2
 

--- a/include/spead2/common_ibv.h
+++ b/include/spead2/common_ibv.h
@@ -203,7 +203,8 @@ public:
 
     /// Create a file descriptor that is ready to read when the completion channel has events
     boost::asio::posix::stream_descriptor wrap(boost::asio::io_service &io_service) const;
-    void get_event(ibv_cq **cq, void **context);
+    /// Get an event, if one is available
+    bool get_event(ibv_cq **cq, void **context);
 };
 
 class ibv_cq_t : public std::unique_ptr<ibv_cq, detail::ibv_cq_deleter>

--- a/include/spead2/recv_udp_ibv.h
+++ b/include/spead2/recv_udp_ibv.h
@@ -148,9 +148,11 @@ void udp_ibv_reader_base<Derived>::packet_handler(const boost::system::error_cod
         {
             ibv_cq *event_cq;
             void *event_context;
-            comp_channel.get_event(&event_cq, &event_context);
-            // TODO: defer acks until shutdown
-            recv_cq.ack_events(1);
+            while (comp_channel.get_event(&event_cq, &event_context))
+            {
+                // TODO: defer acks until shutdown
+                recv_cq.ack_events(1);
+            }
         }
         if (state.is_stopped())
         {

--- a/src/common_ibv.cpp
+++ b/src/common_ibv.cpp
@@ -188,13 +188,19 @@ boost::asio::posix::stream_descriptor ibv_comp_channel_t::wrap(
     return wrap_fd(io_service, get()->fd);
 }
 
-void ibv_comp_channel_t::get_event(ibv_cq **cq, void **context)
+bool ibv_comp_channel_t::get_event(ibv_cq **cq, void **context)
 {
     assert(get());
     errno = 0;
     int status = ibv_get_cq_event(get(), cq, context);
     if (status < 0)
-        throw_errno("ibv_get_cq_event failed");
+    {
+        if (errno == EAGAIN)
+            return false;
+        else
+            throw_errno("ibv_get_cq_event failed");
+    }
+    return true;
 }
 
 ibv_cq_t::ibv_cq_t(

--- a/src/send_udp_ibv.cpp
+++ b/src/send_udp_ibv.cpp
@@ -98,9 +98,10 @@ bool udp_ibv_stream::make_space()
             {
                 ibv_cq *event_cq;
                 void *event_cq_context;
-                // This should be non-blocking, since we were woken up
-                comp_channel.get_event(&event_cq, &event_cq_context);
-                send_cq.ack_events(1);
+                // This should be non-blocking, since we were woken up, but
+                // spurious wakeups have been observed.
+                while (comp_channel.get_event(&event_cq, &event_cq_context))
+                    send_cq.ack_events(1);
                 async_send_packets();
             }
         };


### PR DESCRIPTION
This has two effects:
- If epoll spuriously indicates that there is an event to read, it
  prevents the worker thread throwing an exception. This seems to happen
  when using a thread pool with multiple threads. I haven't yet
  determined if that's a bug in Boost.Asio, in the Mellanox drivers, or
  is just expected.
- If a notification is requested, but then new completion queue entries
  are observed before waiting for the notification, it's possible for
  the notification to just lurk in the queue and later cause an
  unnecessary wakeup. I don't know if that can actually happen (it's
  unclear from the documentation whether a second notification request
  will cause a second notification in the completion channel), but we're
  now better protected against it.