### PR TITLE
Support unicast in ibverbs receiver paths

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -15,7 +15,7 @@ Changelog
 - Fix occasional crash when using thread pool with more than one thread
   together with ibverbs.
 - Fix bug in mcdump causing it to hang if the arguments couldn't be parsed
-  and capturing to file.
+  (only happened when capturing to file).
 
 .. rubric:: 2.0.2
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,6 +13,8 @@ Changelog
 - Show the values of immediate items in :program:`spead2_recv`.
 - Fix occasional crash when using thread pool with more than one thread
   together with ibverbs.
+- Fix bug in mcdump causing it to hang if the arguments couldn't be parsed
+  and capturing to file.
 
 .. rubric:: 2.0.2
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,12 @@ Changelog
 
 .. rubric:: Development version
 
+- Support unicast receive with ibverbs acceleration.
+- Fix :program:`spead2_recv` listening only on loopback when given just a port
+  number.
+- Support unicast addresses in a few APIs that previously only accepted
+  multicast addresses; in most cases the unicast address must match the
+  interface address.
 - Add missing ``<map>`` include to ``<spead2/recv_heap.h>``.
 - Show the values of immediate items in :program:`spead2_recv`.
 - Fix occasional crash when using thread pool with more than one thread

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,7 +3,8 @@ Changelog
 
 .. rubric:: Development version
 
-- Support unicast receive with ibverbs acceleration.
+- Support unicast receive with ibverbs acceleration (including in
+  :program:`mcdump`).
 - Fix :program:`spead2_recv` listening only on loopback when given just a port
   number.
 - Support unicast addresses in a few APIs that previously only accepted

--- a/doc/py-ibverbs.rst
+++ b/doc/py-ibverbs.rst
@@ -8,9 +8,9 @@ of libibverbs.
 
 There are a number of limitations in the current implementation:
 
- - Only IPv4 is supported
- - VLAN tagging, IP optional headers, and IP fragmentation are not supported
- - Only multicast is supported.
+ - Only IPv4 is supported.
+ - VLAN tagging, IP optional headers, and IP fragmentation are not supported.
+ - For sending, only multicast is supported.
 
 Within these limitations, it is quite easy to take advantage of this faster
 code path. The main difficulty is that one *must* specify the IP address of
@@ -55,7 +55,11 @@ The ibverbs API can be used programmatically by using an extra method of
       place of `endpoints`.
 
       :param list endpoints: List of 2-tuples, each containing a
-        hostname/IP address the multicast group and the UDP port number.
+        hostname/IP address and the UDP port number. The address may be either
+        unicast or multicast, but in the former case there must be
+        an interface with that IP address (usually it will be the same as
+        `interface_address`, but this is not required as an interface may have
+        multiple IP addresses).
       :param str interface_address: Hostname/IP address of the interface which
         will be subscribed
       :param int max_size: Maximum packet size that will be accepted

--- a/doc/py-recv.rst
+++ b/doc/py-recv.rst
@@ -112,7 +112,9 @@ it, or repeatedly call :py:meth:`~spead2.recv.Stream.get`.
 
    .. py:method:: add_udp_reader(multicast_group, port, max_size=DEFAULT_UDP_MAX_SIZE, buffer_size=DEFAULT_UDP_BUFFER_SIZE, interface_address)
 
-      Feed data from a UDP port with multicast (IPv4 only).
+      Feed data from a UDP port (IPv4 only). This is intended for use with
+      multicast, but it will also accept a unicast address as long as it is the
+      same as the interface address.
 
       :param str multicast_group: Hostname/IP address of the multicast group to subscribe to
       :param int port: UDP port number

--- a/doc/tools.rst
+++ b/doc/tools.rst
@@ -44,7 +44,7 @@ tuning that allow for exploration.
 mcdump
 ------
 mcdump is a tool similar to tcpdump_, but specialised for high-speed capture of
-multicast UDP traffic using hardware that supports the Infiniband Verbs API. It
+UDP traffic using hardware that supports the Infiniband Verbs API. It
 has only been tested on Mellanox ConnectX-3 and ConnectX-5 NICs. Like gulp_, it
 uses a separate thread for disk I/O and CPU core affinity to achieve reliable
 performance. With a sufficiently fast disk subsystem, it is able to capture
@@ -77,6 +77,11 @@ multicast group *yy.yy.yy.yy* on UDP port *zzzz*. mcdump will take care of
 subscribing to the multicast group. Note that only IPv4 is supported. Capture
 continues until interrupted by :kbd:`Ctrl-C`. You can also list more
 :samp:`{group}:{port}` pairs, which will all stored in the same pcap file.
+
+While originally written for multicast, mcdump also supports unicast. An IP
+address must still be provided; usually it will be the same as the interface
+address, but it could be a different address if the interface has multiple IP
+addresses.
 
 You can also specify ``-`` in place of the filename to suppress the write to
 file. This is useful to simply count the bytes/packets received without being
@@ -115,7 +120,7 @@ Limitations
   detected at compile time. Otherwise, all packets have a zero timestamp in the
   file.
 
-- Only IPv4 multicast is supported.
+- Only IPv4 is supported.
 
 - It is not optimised for small packets (below about 1KB). Packet capture rates
   top out around 6Mpps for current hardware.

--- a/include/spead2/common_ibv.h
+++ b/include/spead2/common_ibv.h
@@ -272,6 +272,8 @@ public:
 
 /**
  * Create a single flow rule.
+ *
+ * @pre The endpoint contains an IPv4 address.
  */
 ibv_flow_t create_flow(
     const ibv_qp_t &qp, const boost::asio::ip::udp::endpoint &endpoint,
@@ -282,7 +284,7 @@ ibv_flow_t create_flow(
  *
  * If the address in an endpoint is unspecified, it will not be filtered on.
  * Multicast addresses are supported; unicast addresses must have corresponding
- * interfaces (which is used to retrieve the corresponding MAC address).
+ * interfaces (which are used to retrieve the corresponding MAC addresses).
  *
  * @pre The @a endpoints are IPv4 addresses.
  */

--- a/include/spead2/common_ibv.h
+++ b/include/spead2/common_ibv.h
@@ -1,4 +1,4 @@
-/* Copyright 2016-2019 SKA South Africa
+/* Copyright 2016-2020 SKA South Africa
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -272,17 +272,10 @@ public:
 
 /**
  * Create a single flow rule.
- *
- * The @a mask specifies a subset of bits in the IPv4 address that must match
- * (in host byte order, so for example 0xFFFFFF00 specifies a /24 subnet).
- * Note that not all IB drivers support a mask other than the default (all
- * 1's).
- *
- * @pre The endpoint contains an IPv4 multicast address.
  */
 ibv_flow_t create_flow(
     const ibv_qp_t &qp, const boost::asio::ip::udp::endpoint &endpoint,
-    int port_num, std::uint32_t mask = 0xFFFFFFFF);
+    int port_num);
 
 /**
  * Create flow rules to subscribe to a given set of multicast endpoints.

--- a/include/spead2/common_ibv.h
+++ b/include/spead2/common_ibv.h
@@ -278,13 +278,13 @@ ibv_flow_t create_flow(
     int port_num);
 
 /**
- * Create flow rules to subscribe to a given set of multicast endpoints.
+ * Create flow rules to subscribe to a given set of endpoints.
  *
- * Where supported by the driver, it will coalesce multiple endpoints into a
- * single flow rule with a mask. This only applies per-port; it does not try
- * to identify subscriptions to multiple ports on the same address.
+ * If the address in an endpoint is unspecified, it will not be filtered on.
+ * Multicast addresses are supported; unicast addresses must have corresponding
+ * interfaces (which is used to retrieve the corresponding MAC address).
  *
- * @pre The endpoints are IPv4 multicast addresses.
+ * @pre The @a endpoints are IPv4 addresses.
  */
 std::vector<ibv_flow_t> create_flows(
     const ibv_qp_t &qp, const std::vector<boost::asio::ip::udp::endpoint> &endpoints,

--- a/include/spead2/recv_udp.h
+++ b/include/spead2/recv_udp.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 SKA South Africa
+/* Copyright 2015, 2020 SKA South Africa
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -99,20 +99,26 @@ public:
         std::size_t buffer_size = default_buffer_size);
 
     /**
-     * Constructor with explicit multicast interface address (IPv4 only).
+     * Constructor with explicit interface address (IPv4 only).
      *
-     * The socket will have @c SO_REUSEADDR set, so that multiple sockets can
-     * all listen to the same multicast stream. If you want to let the
-     * system pick the interface for the multicast subscription, use
-     * @c boost::asio::ip::address_v4::any(), or use the default constructor.
+     * This overload is designed for use with multicast, but can also be used
+     * with a unicast endpoint as long as the address matches the interface
+     * address.
+     *
+     * When a multicast group is used, the socket will have @c SO_REUSEADDR
+     * set, so that multiple sockets can all listen to the same multicast
+     * stream. If you want to let the system pick the interface for the
+     * multicast subscription, use @c boost::asio::ip::address_v4::any(), or
+     * use the default constructor.
      *
      * @param owner        Owning stream
-     * @param endpoint     Multicast group and port
+     * @param endpoint     Address and port
      * @param max_size     Maximum packet size that will be accepted.
      * @param buffer_size  Requested socket buffer size.
      * @param interface_address  Address of the interface which should join the group
      *
-     * @throws std::invalid_argument If @a endpoint is not an IPv4 multicast address
+     * @throws std::invalid_argument If @a endpoint is not an IPv4 multicast address and
+     *                               does not match @a interface_address.
      * @throws std::invalid_argument If @a interface_address is not an IPv4 address
      */
     udp_reader(

--- a/include/spead2/recv_udp_ibv.h
+++ b/include/spead2/recv_udp_ibv.h
@@ -1,4 +1,4 @@
-/* Copyright 2016, 2019 SKA South Africa
+/* Copyright 2016, 2019-2020 SKA South Africa
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -228,7 +228,7 @@ void udp_ibv_reader_base<Derived>::enqueue_receive(bool need_poll)
 
 /**
  * Synchronous or asynchronous stream reader that reads UDP packets using
- * the Infiniband verbs API. It currently only supports multicast IPv4, with
+ * the Infiniband verbs API. It currently only supports IPv4, with
  * no fragmentation, IP header options, or VLAN tags.
  */
 class udp_ibv_reader : public detail::udp_ibv_reader_base<udp_ibv_reader>
@@ -266,7 +266,11 @@ public:
      * Constructor.
      *
      * @param owner        Owning stream
-     * @param endpoint     Multicast group and port
+     * @param endpoint     Address and port. Note that is it possible for the address to be
+     *                     unicast and different to the @a interface_address: the interface
+     *                     may have multiple IP addresses, in which case this filters packets
+     *                     on the interface by IP address. An unspecified address can also be
+     *                     used to skip address filtering.
      * @param interface_address  Address of the interface which should join the group and listen for data
      * @param max_size     Maximum packet size that will be accepted
      * @param buffer_size  Requested memory allocation for work requests. Note
@@ -287,7 +291,8 @@ public:
      *                     non-negative) or letting other code run on the
      *                     thread (if @a comp_vector is negative).
      *
-     * @throws std::invalid_argument If @a endpoint is not an IPv4 multicast address
+     * @throws std::invalid_argument If @a endpoint is specified and is not an
+     *                               IPv4 address
      * @throws std::invalid_argument If @a interface_address is not an IPv4 address
      */
     udp_ibv_reader(
@@ -303,7 +308,11 @@ public:
      * Constructor with multiple endpoints.
      *
      * @param owner        Owning stream
-     * @param endpoints    Multicast groups and ports
+     * @param endpoints    Addresses and ports. Note that is it possible for the addresses to be
+     *                     unicast and different to the @a interface_address: the interface
+     *                     may have multiple IP addresses, in which case this filters packets
+     *                     on the interface by IP address. An unspecified address can also be
+     *                     used to skip address filtering.
      * @param interface_address  Address of the interface which should join the group and listen for data
      * @param max_size     Maximum packet size that will be accepted
      * @param buffer_size  Requested memory allocation for work requests. Note
@@ -324,7 +333,8 @@ public:
      *                     non-negative) or letting other code run on the
      *                     thread (if @a comp_vector is negative).
      *
-     * @throws std::invalid_argument If any element of @a endpoints is not an IPv4 multicast address
+     * @throws std::invalid_argument If any element of @a endpoints is specified and is not
+     *                               an IPv4 address
      * @throws std::invalid_argument If @a interface_address is not an IPv4 address
      */
     udp_ibv_reader(

--- a/spead2/tools/bench_asyncio.py
+++ b/spead2/tools/bench_asyncio.py
@@ -88,12 +88,7 @@ class SlaveConnection:
                     stream.set_memory_allocator(memory_pool)
                     if args.memcpy_nt:
                         stream.set_memcpy(spead2.MEMCPY_NONTEMPORAL)
-                    if args.multicast is not None:
-                        bind_hostname = args.multicast
-                    elif args.recv_ibv is not None:
-                        bind_hostname = args.recv_ibv
-                    else:
-                        bind_hostname = ''
+                    bind_hostname = '' if args.multicast is None else args.multicast
                     if 'recv_ibv' in args and args.recv_ibv is not None:
                         try:
                             stream.add_udp_ibv_reader(

--- a/spead2/tools/bench_asyncio.py
+++ b/spead2/tools/bench_asyncio.py
@@ -88,7 +88,12 @@ class SlaveConnection:
                     stream.set_memory_allocator(memory_pool)
                     if args.memcpy_nt:
                         stream.set_memcpy(spead2.MEMCPY_NONTEMPORAL)
-                    bind_hostname = '' if args.multicast is None else args.multicast
+                    if args.multicast is not None:
+                        bind_hostname = args.multicast
+                    elif args.recv_ibv is not None:
+                        bind_hostname = args.recv_ibv
+                    else:
+                        bind_hostname = ''
                     if 'recv_ibv' in args and args.recv_ibv is not None:
                         try:
                             stream.add_udp_ibv_reader(

--- a/spead2/tools/recv_asyncio.py
+++ b/spead2/tools/recv_asyncio.py
@@ -42,7 +42,7 @@ def get_args():
 
     group = parser.add_argument_group('Protocol options')
     group.add_argument('--tcp', action='store_true', help='Receive data over TCP instead of UDP')
-    group.add_argument('--bind', type=str, default='', help='Interface address (used for multicast and when no address is specified)')
+    group.add_argument('--bind', type=str, default='', help='Interface address')
     group.add_argument('--pyspead', action='store_true', help='Be bug-compatible with PySPEAD')
     group.add_argument('--joint', action='store_true', help='Treat all sources as a single stream')
     group.add_argument('--packet', type=int, default=spead2.recv.Stream.DEFAULT_UDP_MAX_SIZE,
@@ -153,13 +153,11 @@ def main():
                 except AttributeError:
                     raise RuntimeError('spead2 was compiled without pcap support') from None
             else:
-                if args.bind and not host:
-                    host = args.bind
                 if args.tcp:
                     stream.add_tcp_reader(port, args.packet, args.buffer, host)
                 elif 'ibv' in args and args.ibv:
                     ibv_endpoints.append((host, port))
-                elif args.bind and host != args.bind:
+                elif args.bind:
                     stream.add_udp_reader(host, port, args.packet, args.buffer, args.bind)
                 else:
                     stream.add_udp_reader(port, args.packet, args.buffer, host)

--- a/spead2/tools/recv_asyncio.py
+++ b/spead2/tools/recv_asyncio.py
@@ -159,7 +159,7 @@ def main():
                     stream.add_tcp_reader(port, args.packet, args.buffer, host)
                 elif 'ibv' in args and args.ibv:
                     ibv_endpoints.append((host, port))
-                elif args.bind and host:
+                elif args.bind and host != args.bind:
                     stream.add_udp_reader(host, port, args.packet, args.buffer, args.bind)
                 else:
                     stream.add_udp_reader(port, args.packet, args.buffer, host)

--- a/spead2/tools/recv_asyncio.py
+++ b/spead2/tools/recv_asyncio.py
@@ -1,4 +1,4 @@
-# Copyright 2015, 2017-2019 SKA South Africa
+# Copyright 2015, 2017-2020 SKA South Africa
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -42,7 +42,7 @@ def get_args():
 
     group = parser.add_argument_group('Protocol options')
     group.add_argument('--tcp', action='store_true', help='Receive data over TCP instead of UDP')
-    group.add_argument('--bind', type=str, default='', help='Interface address for multicast')
+    group.add_argument('--bind', type=str, default='', help='Interface address (used for multicast and when no address is specified)')
     group.add_argument('--pyspead', action='store_true', help='Be bug-compatible with PySPEAD')
     group.add_argument('--joint', action='store_true', help='Treat all sources as a single stream')
     group.add_argument('--packet', type=int, default=spead2.recv.Stream.DEFAULT_UDP_MAX_SIZE,
@@ -153,11 +153,11 @@ def main():
                 except AttributeError:
                     raise RuntimeError('spead2 was compiled without pcap support') from None
             else:
+                if args.bind and not host:
+                    host = args.bind
                 if args.tcp:
                     stream.add_tcp_reader(port, args.packet, args.buffer, host)
                 elif 'ibv' in args and args.ibv:
-                    if host is None:
-                        raise ValueError('a multicast group is required when using --ibv')
                     ibv_endpoints.append((host, port))
                 elif args.bind and host:
                     stream.add_udp_reader(host, port, args.packet, args.buffer, args.bind)

--- a/src/py_recv.cpp
+++ b/src/py_recv.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2017 SKA South Africa
+/* Copyright 2015, 2017, 2020 SKA South Africa
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/src/py_recv.cpp
+++ b/src/py_recv.cpp
@@ -224,27 +224,27 @@ public:
         emplace_reader<udp_reader>(std::move(asio_socket), max_size);
     }
 
-    void add_udp_reader_multicast_v4(
-        const std::string &multicast_group,
+    void add_udp_reader_bind_v4(
+        const std::string &address,
         std::uint16_t port,
         std::size_t max_size,
         std::size_t buffer_size,
         const std::string &interface_address)
     {
         py::gil_scoped_release gil;
-        auto endpoint = make_endpoint<boost::asio::ip::udp>(multicast_group, port);
+        auto endpoint = make_endpoint<boost::asio::ip::udp>(address, port);
         emplace_reader<udp_reader>(endpoint, max_size, buffer_size, make_address(interface_address));
     }
 
-    void add_udp_reader_multicast_v6(
-        const std::string &multicast_group,
+    void add_udp_reader_bind_v6(
+        const std::string &address,
         std::uint16_t port,
         std::size_t max_size,
         std::size_t buffer_size,
         unsigned int interface_index)
     {
         py::gil_scoped_release gil;
-        auto endpoint = make_endpoint<boost::asio::ip::udp>(multicast_group, port);
+        auto endpoint = make_endpoint<boost::asio::ip::udp>(address, port);
         emplace_reader<udp_reader>(endpoint, max_size, buffer_size, interface_index);
     }
 
@@ -270,7 +270,7 @@ public:
 
 #if SPEAD2_USE_IBV
     void add_udp_ibv_reader_single(
-        const std::string &multicast_group,
+        const std::string &address,
         std::uint16_t port,
         const std::string &interface_address,
         std::size_t max_size,
@@ -279,7 +279,7 @@ public:
         int max_poll)
     {
         py::gil_scoped_release gil;
-        auto endpoint = make_endpoint<boost::asio::ip::udp>(multicast_group, port);
+        auto endpoint = make_endpoint<boost::asio::ip::udp>(address, port);
         emplace_reader<udp_ibv_reader>(endpoint, make_address(interface_address),
                                        max_size, buffer_size, comp_vector, max_poll);
     }
@@ -297,9 +297,9 @@ public:
         for (size_t i = 0; i < len(endpoints); i++)
         {
             py::sequence endpoint = endpoints[i].cast<py::sequence>();
-            std::string multicast_group = endpoint[0].cast<std::string>();
+            std::string address = endpoint[0].cast<std::string>();
             std::uint16_t port = endpoint[1].cast<std::uint16_t>();
-            endpoints2.push_back(make_endpoint<boost::asio::ip::udp>(multicast_group, port));
+            endpoints2.push_back(make_endpoint<boost::asio::ip::udp>(address, port));
         }
         py::gil_scoped_release gil;
         emplace_reader<udp_ibv_reader>(endpoints2, make_address(interface_address),
@@ -430,13 +430,13 @@ py::module register_module(py::module &parent)
         .def("add_udp_reader", SPEAD2_PTMF(ring_stream_wrapper, add_udp_reader_socket),
               "socket"_a,
               "max_size"_a = udp_reader::default_max_size)
-        .def("add_udp_reader", SPEAD2_PTMF(ring_stream_wrapper, add_udp_reader_multicast_v4),
+        .def("add_udp_reader", SPEAD2_PTMF(ring_stream_wrapper, add_udp_reader_bind_v4),
               "multicast_group"_a,
               "port"_a,
               "max_size"_a = udp_reader::default_max_size,
               "buffer_size"_a = udp_reader::default_buffer_size,
               "interface_address"_a = "0.0.0.0")
-        .def("add_udp_reader", SPEAD2_PTMF(ring_stream_wrapper, add_udp_reader_multicast_v6),
+        .def("add_udp_reader", SPEAD2_PTMF(ring_stream_wrapper, add_udp_reader_bind_v6),
               "multicast_group"_a,
               "port"_a,
               "max_size"_a = udp_reader::default_max_size,

--- a/src/recv_udp_ibv.cpp
+++ b/src/recv_udp_ibv.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2016 SKA South Africa
+/* Copyright 2016-2020 SKA South Africa
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -80,10 +80,10 @@ udp_ibv_reader_core::udp_ibv_reader_core(
     stop_poll(false)
 {
     for (const auto &endpoint : endpoints)
-        if (!endpoint.address().is_v4() || !endpoint.address().is_multicast())
+        if (!endpoint.address().is_v4())
         {
             std::ostringstream msg;
-            msg << "endpoint " << endpoint << " is not an IPv4 multicast address";
+            msg << "endpoint " << endpoint << " is not an IPv4 address";
             throw std::invalid_argument(msg.str());
         }
     if (max_poll <= 0)
@@ -104,8 +104,11 @@ void udp_ibv_reader_core::join_groups(
 {
     join_socket.set_option(boost::asio::socket_base::reuse_address(true));
     for (const auto &endpoint : endpoints)
-        join_socket.set_option(boost::asio::ip::multicast::join_group(
-            endpoint.address().to_v4(), interface_address.to_v4()));
+        if (endpoint.address().is_multicast())
+        {
+            join_socket.set_option(boost::asio::ip::multicast::join_group(
+                endpoint.address().to_v4(), interface_address.to_v4()));
+        }
 }
 
 void udp_ibv_reader_core::stop()

--- a/src/recv_udp_ibv.cpp
+++ b/src/recv_udp_ibv.cpp
@@ -80,7 +80,7 @@ udp_ibv_reader_core::udp_ibv_reader_core(
     stop_poll(false)
 {
     for (const auto &endpoint : endpoints)
-        if (!endpoint.address().is_v4())
+        if (!endpoint.address().is_unspecified() && !endpoint.address().is_v4())
         {
             std::ostringstream msg;
             msg << "endpoint " << endpoint << " is not an IPv4 address";

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2017, 2019 SKA South Africa
+/* Copyright 2015, 2017, 2019-2020 SKA South Africa
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -687,8 +687,10 @@ static void main_slave(int argc, const char **argv)
                 opts.recv_ibv_if = decode_string(opts.recv_ibv_if);
                 /* Look up the bind address for the data socket */
                 udp::resolver resolver(thread_pool.get_io_service());
-                udp::resolver::query query(opts.multicast.empty() ? "0.0.0.0" : opts.multicast,
-                                           slave_opts.port);
+                udp::resolver::query query(
+                    !opts.multicast.empty() ? opts.multicast :
+                    !opts.recv_ibv_if.empty() ? opts.recv_ibv_if : "0.0.0.0",
+                    slave_opts.port);
                 udp::endpoint endpoint = *resolver.resolve(query);
                 if (opts.ring)
                     connection.reset(new recv_connection_ring(opts));

--- a/src/spead2_recv.cpp
+++ b/src/spead2_recv.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2018, 2019 SKA South Africa
+/* Copyright 2015, 2018-2020 SKA South Africa
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -106,7 +106,7 @@ static options parse_args(int argc, const char **argv)
         ("pyspead", make_opt(opts.pyspead), "Be bug-compatible with PySPEAD")
         ("joint", make_opt(opts.joint), "Treat all sources as a single stream")
         ("tcp", make_opt(opts.tcp), "Receive data over TCP instead of UDP")
-        ("bind", make_opt(opts.bind), "Interface address for multicast")
+        ("bind", make_opt(opts.bind), "Interface address (used for multicast and when no address is specified)")
         ("packet", make_opt_no_default(opts.packet), "Maximum packet size to use")
         ("buffer", make_opt_no_default(opts.buffer), "Socket buffer size")
         ("threads", make_opt(opts.threads), "Number of worker threads")
@@ -319,6 +319,8 @@ static std::unique_ptr<spead2::recv::stream> make_stream(
         }
         else
             port = *i;
+        if (host.empty())
+            host = opts.bind;
 
         bool is_pcap = false;
         try
@@ -366,8 +368,6 @@ static std::unique_ptr<spead2::recv::stream> make_stream(
             }
             else
             {
-                if (!opts.bind.empty())
-                    std::cerr << "--bind is only applicable to IPv4 multicast, ignoring\n";
                 stream->emplace_reader<spead2::recv::udp_reader>(endpoint, opts.packet, opts.buffer);
             }
         }

--- a/src/spead2_recv.cpp
+++ b/src/spead2_recv.cpp
@@ -350,7 +350,9 @@ static std::unique_ptr<spead2::recv::stream> make_stream(
         else
         {
             udp::resolver resolver(thread_pool.get_io_service());
-            udp::resolver::query query(host, port);
+            udp::resolver::query query(host, port,
+                boost::asio::ip::udp::resolver::query::address_configured
+                | boost::asio::ip::udp::resolver::query::passive);
             udp::endpoint endpoint = *resolver.resolve(query);
 #if SPEAD2_USE_IBV
             if (opts.ibv)

--- a/src/spead2_recv.cpp
+++ b/src/spead2_recv.cpp
@@ -106,7 +106,7 @@ static options parse_args(int argc, const char **argv)
         ("pyspead", make_opt(opts.pyspead), "Be bug-compatible with PySPEAD")
         ("joint", make_opt(opts.joint), "Treat all sources as a single stream")
         ("tcp", make_opt(opts.tcp), "Receive data over TCP instead of UDP")
-        ("bind", make_opt(opts.bind), "Interface address (used for multicast and when no address is specified)")
+        ("bind", make_opt(opts.bind), "Interface address")
         ("packet", make_opt_no_default(opts.packet), "Maximum packet size to use")
         ("buffer", make_opt_no_default(opts.buffer), "Socket buffer size")
         ("threads", make_opt(opts.threads), "Number of worker threads")
@@ -319,8 +319,6 @@ static std::unique_ptr<spead2::recv::stream> make_stream(
         }
         else
             port = *i;
-        if (host.empty())
-            host = opts.bind;
 
         bool is_pcap = false;
         try
@@ -361,8 +359,7 @@ static std::unique_ptr<spead2::recv::stream> make_stream(
             }
             else
 #endif
-            if (endpoint.address().is_multicast() && endpoint.address().is_v4()
-                && !opts.bind.empty())
+            if (endpoint.address().is_v4() && !opts.bind.empty())
             {
                 stream->emplace_reader<spead2::recv::udp_reader>(
                     endpoint, opts.packet, opts.buffer,
@@ -370,6 +367,8 @@ static std::unique_ptr<spead2::recv::stream> make_stream(
             }
             else
             {
+                if (!opts.bind.empty())
+                    std::cerr << "--bind is not implemented for IPv6\n";
                 stream->emplace_reader<spead2::recv::udp_reader>(endpoint, opts.packet, opts.buffer);
             }
         }


### PR DESCRIPTION
This includes
- library APIs
- spead2_recv and spead_recv.py test programs
- spead2_bench and spead2_bench.py benchmark programs
- mcdump
There are also a few tweaks to interpretation of arguments in the non-verbs code-paths for consistency.