### PR TITLE
Explicitly link to libibverbs in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,7 +165,7 @@ SPEAD2_ARG_WITH(
 ### Determine libraries to link against
 
 LIBS="-lboost_system -lpthread -ldl"
-AS_IF([test "x$SPEAD2_USE_IBV" = "x1"], [LIBS="$LIBS"])
+AS_IF([test "x$SPEAD2_USE_IBV" = "x1"], [LIBS="-libverbs $LIBS"])
 AS_IF([test "x$SPEAD2_USE_PCAP" = "x1"], [LIBS="-lpcap $LIBS"])
 
 ### Build variants


### PR DESCRIPTION
Compilation under CentOS 8, was not adding -libverbs to the link command line, this modification fixed that issue.