### PR TITLE
Forcibly undefined ibverbs functions after including the header

### DIFF
--- a/gen/gen_ibv_loader.py
+++ b/gen/gen_ibv_loader.py
@@ -132,6 +132,10 @@ HEADER = PREFIX + '''\
 #include <infiniband/verbs.h>
 #include <rdma/rdma_cma.h>
 
+{% for node in nodes -%}
+#undef {{ node.name }}
+{% endfor %}
+
 namespace spead2
 {
 


### PR DESCRIPTION
This should fix #90.