### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,11 +6,12 @@ Changelog
 Version 3.0 contains a number of breaking API changes. For information on
 updating your existing code, refer to :doc:`migrate-3`.
 
-New features:
+Other changes:
 
 - Support multiple "substreams" in a send stream (see :ref:`py-substreams`).
 - Reduce overhead for dealing with incomplete heaps.
 - Add C++ preprocessor defines for the version number.
+- Drop support for Python 3.5, which is end-of-life.
 - Change code examples to use standard SPEAD rather than PySPEAD bug compatibility.
 
 Additionally, refer to the changes for 3.0.0b1 below.

--- a/doc/migrate-3.rst
+++ b/doc/migrate-3.rst
@@ -96,6 +96,13 @@ received in any order. Starting with version 3, the default is to assume that
 packets arrive in order. Refer to :ref:`py-packet-ordering` for more
 details.
 
+Loop argument to asyncio functions
+----------------------------------
+The Python asyncio-based classes and functions no longer take a `loop`
+argument. As of Python 3.6 (which is now the minimum supported version),
+:py:func:`asyncio.get_event_loop` returns the executing event loop, so there
+is no need to pass the loop explicitly.
+
 Removal of deprecated functionality
 -----------------------------------
 The following functions were deprecated in version 2 and have been removed in version 3:

--- a/examples/test_recv.py
+++ b/examples/test_recv.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function, division
 import spead2
 import spead2.recv
 import logging

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
 ignore_missing_imports = 1
 files = spead2, examples
-python_version = 3.5
+python_version = 3.6

--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,7 @@ setup(
         'nose',
         'asynctest'
     ],
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     test_suite='nose.collector',
     packages=find_packages(),
     package_data={'': ['py.typed', '*.pyi']},

--- a/spead2/__init__.py
+++ b/spead2/__init__.py
@@ -227,7 +227,7 @@ class Descriptor:
                 fields.append('S1')
             else:
                 if code not in ['u', 'i', 'b']:
-                    raise ValueError('illegal format ({}, {})'.format(code, length))
+                    raise ValueError(f'illegal format ({code}, {length})')
                 fields.append('O')
         return _np.dtype(','.join(fields))
 
@@ -460,12 +460,12 @@ class Item(Descriptor):
                 if code == 'u':
                     raw = int(field)
                     if raw < 0 or raw >= (1 << length):
-                        raise ValueError('{} is out of range for u{}'.format(raw, length))
+                        raise ValueError(f'{raw} is out of range for u{length}')
                 elif code == 'i':
                     top_bit = 1 << (length - 1)
                     raw = int(field)
                     if raw < -top_bit or raw >= top_bit:
-                        raise ValueError('{} is out of range for i{}'.format(field, length))
+                        raise ValueError(f'{field} is out of range for i{length}')
                     # convert to 2's complement
                     if raw < 0:
                         raw += 2 * top_bit
@@ -584,7 +584,7 @@ class Item(Descriptor):
             value = [self.value[i : i + 1] for i in range(len(self.value))]
         value = _np.array(value, dtype=self._internal_dtype, order=self.order, copy=False)
         if not self.compatible_shape(value.shape):
-            raise ValueError('Value has shape {}, expected {}'.format(value.shape, self.shape))
+            raise ValueError(f'Value has shape {value.shape}, expected {self.shape}')
         return value
 
     def to_buffer(self):

--- a/spead2/send/__init__.py
+++ b/spead2/send/__init__.py
@@ -15,7 +15,6 @@
 
 """Send SPEAD protocol"""
 
-from __future__ import print_function, division
 import weakref
 
 import spead2 as _spead2

--- a/spead2/send/asyncio.py
+++ b/spead2/send/asyncio.py
@@ -16,7 +16,6 @@
 """
 Integration between spead2.send and asyncio
 """
-from __future__ import absolute_import
 
 import asyncio
 

--- a/spead2/test/shutdown.py
+++ b/spead2/test/shutdown.py
@@ -20,7 +20,7 @@ def test_logging_shutdown():
     # Set a log level that won't actually display the messages.
     logging.basicConfig(level=logging.ERROR)
     for i in range(20000):
-        spead2._spead2.log_info('Test message {}'.format(i))
+        spead2._spead2.log_info(f'Test message {i}')
 
 
 def test_running_thread_pool():

--- a/spead2/test/test_common.py
+++ b/spead2/test/test_common.py
@@ -15,8 +15,6 @@
 
 """Tests for parts of spead2 that are shared between send and receive"""
 
-from __future__ import division, print_function
-
 import numpy as np
 from nose.tools import (
     assert_equal, assert_greater, assert_raises, assert_true, assert_false,

--- a/spead2/test/test_passthrough.py
+++ b/spead2/test/test_passthrough.py
@@ -15,7 +15,6 @@
 
 """Test that data can be passed over the SPEAD protocol using the various transports."""
 
-from __future__ import division, print_function
 import os
 import socket
 import sys
@@ -81,7 +80,7 @@ class BaseTestPassthrough:
         sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
         try:
             sock.bind(("::1", 8888))
-        except IOError:
+        except OSError:
             raise SkipTest('platform cannot bind IPv6 localhost address')
         finally:
             sock.close()
@@ -207,7 +206,7 @@ class BaseTestPassthrough:
         """
         ig = spead2.send.ItemGroup()
         for i in range(50):
-            name = 'test item {}'.format(i)
+            name = f'test item {i}'
             ig.add_item(id=0x2345 + i, name=name, description=name,
                         shape=(), format=[('u', 40)], value=0x12345 * i)
         self._test_item_group(ig)

--- a/spead2/test/test_passthrough_asyncio.py
+++ b/spead2/test/test_passthrough_asyncio.py
@@ -182,7 +182,7 @@ class TestPassthroughInproc(BaseTestPassthroughSubstreamsAsync):
 
     async def transmit_item_groups_async(self, item_groups, memcpy, allocator, new_order='='):
         self._queues = [spead2.InprocQueue() for ig in item_groups]
-        ret = await super(TestPassthroughInproc, self).transmit_item_groups_async(
+        ret = await super().transmit_item_groups_async(
             item_groups, memcpy, allocator, new_order)
         for queue in self._queues:
             queue.stop()

--- a/spead2/test/test_recv.py
+++ b/spead2/test/test_recv.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division, print_function
 import socket
 import struct
 import time
@@ -198,7 +197,7 @@ class TestDecode:
             if key in kwargs:
                 setattr(ring_config, key, kwargs.pop(key))
         if kwargs:
-            raise ValueError('Unexpected keyword arguments ({})'.format(kwargs))
+            raise ValueError(f'Unexpected keyword arguments ({kwargs})')
         stream = recv.Stream(thread_pool, config, ring_config)
         stream.add_buffer_reader(data)
         return list(stream)
@@ -274,7 +273,7 @@ class TestDecode:
             [
                 self.flavour.make_plain_descriptor(
                     0x1234, 'test_string', 'a byte string', [('c', 8)], [None]),
-                Item(0x1234, 'Hello world'.encode('ascii'))
+                Item(0x1234, b'Hello world')
             ])
         item = self.data_to_item(packet, 0x1234)
         assert_equal('Hello world', item.value)
@@ -539,7 +538,7 @@ class TestDecode:
             [
                 self.flavour.make_plain_descriptor(
                     0x1234, 'test_string', 'a byte string', [('c', 8)], [None]),
-                Item(0x1234, 'Hello world'.encode('ascii'))
+                Item(0x1234, b'Hello world')
             ])
         heaps = self.data_to_heaps(packet1 + packet2, stop_on_stop_item=False)
         assert_equal(2, len(heaps))

--- a/spead2/test/test_recv_asyncio.py
+++ b/spead2/test/test_recv_asyncio.py
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division, print_function
-
 import asynctest
 from nose.tools import assert_equal, assert_true
 

--- a/spead2/test/test_send.py
+++ b/spead2/test/test_send.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division, print_function
 import binascii
 import gc
 import math

--- a/spead2/tools/bench_asyncio.py
+++ b/spead2/tools/bench_asyncio.py
@@ -263,7 +263,7 @@ async def run_master(args):
     if args.quiet:
         print(rate_gbps)
     else:
-        print("Sustainable rate: {:.3f} Gbps".format(rate_gbps))
+        print(f"Sustainable rate: {rate_gbps:.3f} Gbps")
 
 
 def main():

--- a/spead2/tools/recv_asyncio.py
+++ b/spead2/tools/recv_asyncio.py
@@ -99,7 +99,7 @@ async def run_stream(stream, name, args):
                 if num_heaps == args.max_heaps:
                     break
                 heap = await stream.get()
-                print("Received heap {} on stream {}".format(heap.cnt, name))
+                print(f"Received heap {heap.cnt} on stream {name}")
                 num_heaps += 1
                 try:
                     if args.descriptors:
@@ -118,9 +118,9 @@ async def run_stream(stream, name, args):
                         else:
                             print(key)
                 except ValueError as e:
-                    print("Error raised processing heap: {}".format(e))
+                    print(f"Error raised processing heap: {e}")
             except (spead2.Stopped, asyncio.CancelledError):
-                print("Shutting down stream {} after {} heaps".format(name, num_heaps))
+                print(f"Shutting down stream {name} after {num_heaps} heaps")
                 stats = stream.stats
                 for key in dir(stats):
                     if not key.startswith('_'):

--- a/spead2/tools/send_asyncio.py
+++ b/spead2/tools/send_asyncio.py
@@ -174,7 +174,7 @@ async def async_main():
         descriptor_frequency=args.descriptors,
         flavour=spead2.Flavour(4, 64, args.addr_bits, bug_compat))
     for i in range(args.items):
-        item_group.add_item(id=None, name='Test item {}'.format(i),
+        item_group.add_item(id=None, name=f'Test item {i}',
                             description='A test item with arbitrary value',
                             shape=(elements,), dtype=dtype,
                             value=np.zeros((elements,), dtype=dtype))


### PR DESCRIPTION
It's about to be end-of-life, and removing it also allows dropping the explicit `loop` argument (passing it down to asyncio functions is deprecated in recent versions of Python). I figure this is a good time to remove that argument since I'm making other breaking changes in spead2 3.0.

It's probably worth reviewing the commits individually, because the pyupgrade commit is long but completely mechanical.