### PR TITLE
Convert unit tests to pytest

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -37,7 +37,7 @@ if [ "$TEST_PYTHON" = "yes" ]; then
     else
         CC="$CC -Werror" pip install -v .
     fi
-    pytest -v spead2/test
+    pytest
     for test in test_logging_shutdown test_running_thread_pool test_running_stream; do
         echo "Running shutdown test $test"
         python -c "import spead2.test.shutdown; spead2.test.shutdown.$test()"

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -37,14 +37,10 @@ if [ "$TEST_PYTHON" = "yes" ]; then
     else
         CC="$CC -Werror" pip install -v .
     fi
-    # Avoid running nosetests from installation directory, to avoid picking up
-    # things from the local tree that aren't installed.
-    pushd /
-    nosetests --with-ignore-docstring -v spead2
+    pytest -v spead2/test
     for test in test_logging_shutdown test_running_thread_pool test_running_stream; do
         echo "Running shutdown test $test"
         python -c "import spead2.test.shutdown; spead2.test.shutdown.$test()"
     done
-    popd
     flake8
 fi

--- a/RELEASE-PROCESS
+++ b/RELEASE-PROCESS
@@ -6,8 +6,8 @@
 - Check that Travis successfully tested the release
 - Run ./mkwheels.sh
 - Run ./setup.py sdist
-- Install the sdist and check that it passes nosetests
-- Install a wheel and check that it passes nosetests
+- Install the sdist and check that it passes pytest
+- Install a wheel and check that it passes pytest
 - Tag the release, git push --tags
 - Upload the sdist and wheels to PyPI with twine
 - Upload the sdist and debug symbols to github

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = spead2/test

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,8 @@ asynctest
 flake8
 netifaces
 numpy
-nose
-nose-ignore-docstring
 pycparser
 jinja2
+pytest
+pytest-asyncio
+pytest-timeout

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,3 @@
-asynctest
 flake8
 netifaces
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile requirements.in
 #
-asynctest==0.13.0         # via -r requirements.in
 attrs==20.2.0             # via pytest
 entrypoints==0.3          # via flake8
 flake8==3.7.8             # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,16 +4,25 @@
 #
 #    pip-compile requirements.in
 #
-asynctest==0.13.0
+asynctest==0.13.0         # via -r requirements.in
+attrs==20.2.0             # via pytest
 entrypoints==0.3          # via flake8
-flake8==3.7.8
-jinja2==2.10.1
+flake8==3.7.8             # via -r requirements.in
+iniconfig==1.0.1          # via pytest
+jinja2==2.10.1            # via -r requirements.in
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
-netifaces==0.10.9
-nose-ignore-docstring==0.2
-nose==1.3.7
-numpy==1.17.2
+netifaces==0.10.9         # via -r requirements.in
+numpy==1.17.2             # via -r requirements.in
+packaging==20.4           # via pytest
+pluggy==0.13.1            # via pytest
+py==1.9.0                 # via pytest
 pycodestyle==2.5.0        # via flake8
-pycparser==2.19
+pycparser==2.19           # via -r requirements.in
 pyflakes==2.1.1           # via flake8
+pyparsing==2.4.7          # via packaging
+pytest-asyncio==0.14.0    # via -r requirements.in
+pytest-timeout==1.4.2     # via -r requirements.in
+pytest==6.1.0             # via -r requirements.in, pytest-asyncio, pytest-timeout
+six==1.15.0               # via packaging
+toml==0.10.1              # via pytest

--- a/setup.py
+++ b/setup.py
@@ -165,11 +165,11 @@ setup(
     ],
     tests_require=[
         'netifaces',
-        'nose',
-        'asynctest'
+        'pytest',
+        'pytest-asyncio',
+        'pytest-timeout'
     ],
     python_requires='>=3.6',
-    test_suite='nose.collector',
     packages=find_packages(),
     package_data={'': ['py.typed', '*.pyi']},
     entry_points={

--- a/spead2/test/test_common.py
+++ b/spead2/test/test_common.py
@@ -1,4 +1,4 @@
-# Copyright 2015, 2019 SKA South Africa
+# Copyright 2015, 2019-2020 SKA South Africa
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -16,23 +16,20 @@
 """Tests for parts of spead2 that are shared between send and receive"""
 
 import numpy as np
-from nose.tools import (
-    assert_equal, assert_greater, assert_raises, assert_true, assert_false,
-    assert_is, assert_is_not, assert_is_none)
+import pytest
 
 import spead2
 
 
 class TestParseRangeList:
     def test_empty(self):
-        assert_equal([], spead2.parse_range_list(''))
+        assert spead2.parse_range_list('') == []
 
     def test_simple(self):
-        assert_equal([1, 2, 5], spead2.parse_range_list('1,2,5'))
+        assert spead2.parse_range_list('1,2,5') == [1, 2, 5]
 
     def test_ranges(self):
-        assert_equal([100, 4, 5, 6, 8, 10, 12, 13],
-                     spead2.parse_range_list('100,4-6,8,10-10,12-13'))
+        assert spead2.parse_range_list('100,4-6,8,10-10,12-13') == [100, 4, 5, 6, 8, 10, 12, 13]
 
 
 class TestThreadPool:
@@ -49,46 +46,46 @@ class TestThreadPool:
         spead2.ThreadPool(1, [1, 0, 2])
 
     def test_zero_threads(self):
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             spead2.ThreadPool(0)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             spead2.ThreadPool(0, [0, 1])
 
 
 class TestFlavour:
     def test_bad_version(self):
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             spead2.Flavour(3, 64, 40, 0)
 
     def test_bad_item_pointer_bits(self):
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             spead2.Flavour(4, 32, 24, 0)
 
     def test_bad_heap_address_bits(self):
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             spead2.Flavour(4, 64, 43, 0)  # Not multiple of 8
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             spead2.Flavour(4, 64, 0, 0)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             spead2.Flavour(4, 64, 64, 0)
 
     def test_attributes(self):
         flavour = spead2.Flavour(4, 64, 40, 2)
-        assert_equal(4, flavour.version)
-        assert_equal(64, flavour.item_pointer_bits)
-        assert_equal(40, flavour.heap_address_bits)
-        assert_equal(2, flavour.bug_compat)
+        assert flavour.version == 4
+        assert flavour.item_pointer_bits == 64
+        assert flavour.heap_address_bits == 40
+        assert flavour.bug_compat == 2
 
     def test_equality(self):
         flavour1 = spead2.Flavour(4, 64, 40, 2)
         flavour1b = spead2.Flavour(4, 64, 40, 2)
         flavour2 = spead2.Flavour(4, 64, 48, 2)
         flavour3 = spead2.Flavour(4, 64, 40, 4)
-        assert_true(flavour1 == flavour1b)
-        assert_true(flavour1 != flavour2)
-        assert_false(flavour1 != flavour1b)
-        assert_false(flavour1 == flavour2)
-        assert_false(flavour1 == flavour3)
+        assert flavour1 == flavour1b
+        assert flavour1 != flavour2
+        assert not (flavour1 != flavour1b)
+        assert not (flavour1 == flavour2)
+        assert not (flavour1 == flavour3)
 
 
 class TestItem:
@@ -105,59 +102,62 @@ class TestItem:
                             (None,), format=[('c', 8)], value='\u0200')
         item2 = spead2.Item(0x1001, 'name2', 'description2', (),
                             dtype='S5', value='\u0201')
-        assert_raises(UnicodeEncodeError, item1.to_buffer)
-        assert_raises(UnicodeEncodeError, item2.to_buffer)
+        with pytest.raises(UnicodeEncodeError):
+            item1.to_buffer()
+        with pytest.raises(UnicodeEncodeError):
+            item2.to_buffer()
 
     def test_format_and_dtype(self):
         """Specifying both a format and dtype raises :py:exc:`ValueError`."""
-        assert_raises(ValueError, spead2.Item, 0x1000, 'name', 'description',
-                      (1, 2), format=[('c', 8)], dtype='S1')
+        with pytest.raises(ValueError):
+            spead2.Item(0x1000, 'name', 'description',
+                        (1, 2), format=[('c', 8)], dtype='S1')
 
     def test_no_format_or_dtype(self):
         """At least one of format and dtype must be specified."""
-        assert_raises(ValueError, spead2.Item, 0x1000, 'name', 'description',
-                      (1, 2), format=None)
+        with pytest.raises(ValueError):
+            spead2.Item(0x1000, 'name', 'description', (1, 2), format=None)
 
     def test_invalid_order(self):
         """The `order` parameter must be either 'C' or 'F'."""
-        assert_raises(ValueError, spead2.Item, 0x1000, 'name', 'description',
-                      (1, 2), np.int32, order='K')
+        with pytest.raises(ValueError):
+            spead2.Item(0x1000, 'name', 'description', (1, 2), np.int32, order='K')
 
     def test_fortran_fallback(self):
-        """The `order` parameter must be either 'C' for legacy formats."""
-        assert_raises(ValueError, spead2.Item, 0x1000, 'name', 'description',
-                      (1, 2), format=[('u', 32)], order='F')
+        """The `order` parameter must be 'C' for legacy formats."""
+        with pytest.raises(ValueError):
+            spead2.Item(0x1000, 'name', 'description', (1, 2), format=[('u', 32)], order='F')
 
     def test_empty_format(self):
         """Format must not be empty"""
-        assert_raises(ValueError, spead2.Item, 0x1000, 'name', 'description',
-                      (1, 2), format=[])
+        with pytest.raises(ValueError):
+            spead2.Item(0x1000, 'name', 'description', (1, 2), format=[])
 
     def test_assign_none(self):
         """Changing a value back to `None` raises :py:exc:`ValueError`."""
         item = spead2.Item(0x1000, 'name', 'description', (), np.int32)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             item.value = None
 
     def test_multiple_unknown(self):
         """Multiple unknown dimensions are not allowed."""
-        assert_raises(ValueError, spead2.Item, 0x1000, 'name', 'description',
-                      (5, None, 3, None), format=[('u', 32)])
+        with pytest.raises(ValueError):
+            spead2.Item(0x1000, 'name', 'description', (5, None, 3, None), format=[('u', 32)])
 
     def test_numpy_unknown(self):
         """Unknown dimensions are not permitted when using a numpy descriptor"""
-        assert_raises(ValueError, spead2.Item, 0x1000, 'name', 'description',
-                      (5, None), np.int32)
+        with pytest.raises(ValueError):
+            spead2.Item(0x1000, 'name', 'description', (5, None), np.int32)
 
     def test_nonascii_name(self):
         """Name with non-ASCII characters must fail"""
-        with assert_raises(UnicodeEncodeError):
+        with pytest.raises(UnicodeEncodeError):
             item = spead2.Item(0x1000, '\u0200', 'description', (), np.int32)
             item.to_raw(spead2.Flavour())
 
     def test_nonascii_description(self):
         """Description with non-ASCII characters must fail"""
-        with assert_raises(UnicodeEncodeError):
+        with pytest.raises(UnicodeEncodeError):
             item = spead2.Item(0x1000, 'name', '\u0200', (), np.int32)
             item.to_raw(spead2.Flavour())
 
@@ -173,9 +173,9 @@ class TestItemGroup:
         ig.add_item(None, 'item 3', 'item 3', (), np.int32)
         ig.add_item(None, 'item 4', 'item 4', (), np.int32)
         ig.add_item(None, 'item 5', 'item 5', (), np.int32)
-        assert_equal('item 3', ig[0x1001].name)
-        assert_equal('item 4', ig[0x1002].name)
-        assert_equal('item 5', ig[0x1004].name)
+        assert ig[0x1001].name == 'item 3'
+        assert ig[0x1002].name == 'item 4'
+        assert ig[0x1004].name == 'item 5'
 
     def test_replace_rename(self):
         """When a new item is added with a known ID but a different name, the
@@ -183,8 +183,8 @@ class TestItemGroup:
         ig = spead2.ItemGroup()
         ig.add_item(0x1000, 'item 1', 'item 1', (), np.int32)
         ig.add_item(0x1000, 'renamed', 'renamed', (), np.int32)
-        assert_equal([0x1000], list(ig.ids()))
-        assert_equal(['renamed'], list(ig.keys()))
+        assert list(ig.ids()) == [0x1000]
+        assert list(ig.keys()) == ['renamed']
 
     def test_replace_clobber_name(self):
         """When a new item is added that collides with an existing name, that
@@ -192,10 +192,10 @@ class TestItemGroup:
         ig = spead2.ItemGroup()
         ig.add_item(0x1000, 'item 1', 'item 1', (), np.int32)
         ig.add_item(0x1001, 'item 1', 'clobbered', (), np.int32)
-        assert_equal([0x1001], list(ig.ids()))
-        assert_equal(['item 1'], list(ig.keys()))
-        assert_equal('clobbered', ig['item 1'].description)
-        assert_is(ig['item 1'], ig[0x1001])
+        assert list(ig.ids()) == [0x1001]
+        assert list(ig.keys()) == ['item 1']
+        assert ig['item 1'].description == 'clobbered'
+        assert ig['item 1'] is ig[0x1001]
 
     def test_replace_reset_value(self):
         """When a descriptor is replaced with an identical one but a new
@@ -210,12 +210,12 @@ class TestItemGroup:
         item2_version = item2.version
         ig.add_item(0x1000, 'item 1', 'item 1', (), np.int32, value=np.int32(6))
         ig.add_item(0x1001, 'item 2', 'item 2', (), np.int32)
-        assert_is(item1, ig[0x1000])
-        assert_is(item2, ig[0x1001])
-        assert_equal(np.int32(6), item1.value)
-        assert_greater(item1.version, item1_version)
-        assert_equal(np.int32(5), item2.value)
-        assert_equal(item2.version, item2_version)
+        assert item1 is ig[0x1000]
+        assert item2 is ig[0x1001]
+        assert item1.value == np.int32(6)
+        assert item1.version > item1_version
+        assert item2.value == np.int32(5)
+        assert item2_version == item2.version
 
     def test_replace_change_shape(self):
         """When a descriptor changes the shape, the old item must be discarded
@@ -225,9 +225,9 @@ class TestItemGroup:
         item1 = ig[0x1000]
         item1_version = item1.version
         ig.add_item(0x1000, 'item 1', 'bigger', (3, 4), np.int32)
-        assert_is_not(item1, ig[0x1000])
-        assert_is_none(ig[0x1000].value)
-        assert_greater(ig[0x1000].version, item1_version)
+        assert item1 is not ig[0x1000]
+        assert ig[0x1000].value is None
+        assert ig[0x1000].version > item1_version
 
     def test_replace_clobber_both(self):
         """Adding a new item that collides with one item on name and another on
@@ -236,7 +236,7 @@ class TestItemGroup:
         ig.add_item(0x1000, 'item 1', 'item 1', (), np.int32)
         ig.add_item(0x1001, 'item 2', 'item 2', (), np.int32)
         ig.add_item(0x1000, 'item 2', 'clobber', (), np.int32)
-        assert_equal([0x1000], list(ig.ids()))
-        assert_equal(['item 2'], list(ig.keys()))
-        assert_is(ig[0x1000], ig['item 2'])
-        assert_equal('clobber', ig[0x1000].description)
+        assert list(ig.ids()) == [0x1000]
+        assert list(ig.keys()) == ['item 2']
+        assert ig[0x1000] is ig['item 2']
+        assert ig[0x1000].description == 'clobber'

--- a/spead2/test/test_passthrough.py
+++ b/spead2/test/test_passthrough.py
@@ -297,10 +297,11 @@ class TestPassthroughUdp(BaseTestPassthroughSubstreams):
 
     def prepare_senders(self, thread_pool, n):
         if n == 1:
-            return spead2.send.UdpStream(
-                thread_pool, "localhost", 8888,
-                spead2.send.StreamConfig(rate=1e7),
-                buffer_size=0)
+            with pytest.deprecated_call():
+                return spead2.send.UdpStream(
+                    thread_pool, "localhost", 8888,
+                    spead2.send.StreamConfig(rate=1e7),
+                    buffer_size=0)
         else:
             return spead2.send.UdpStream(
                 thread_pool,
@@ -331,10 +332,11 @@ class TestPassthroughUdp6(BaseTestPassthroughSubstreams):
 
     def prepare_senders(self, thread_pool, n):
         if n == 1:
-            return spead2.send.UdpStream(
-                thread_pool, "::1", 8888,
-                spead2.send.StreamConfig(rate=1e7),
-                buffer_size=0)
+            with pytest.deprecated_call():
+                return spead2.send.UdpStream(
+                    thread_pool, "::1", 8888,
+                    spead2.send.StreamConfig(rate=1e7),
+                    buffer_size=0)
         else:
             return spead2.send.UdpStream(
                 thread_pool,
@@ -359,9 +361,10 @@ class TestPassthroughUdpCustomSocket(BaseTestPassthroughSubstreams):
         assert len(self._ports) == n
         send_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         if n == 1:
-            sender = spead2.send.UdpStream(
-                thread_pool, send_sock, "127.0.0.1", self._ports[0],
-                spead2.send.StreamConfig(rate=1e7))
+            with pytest.deprecated_call():
+                sender = spead2.send.UdpStream(
+                    thread_pool, send_sock, "127.0.0.1", self._ports[0],
+                    spead2.send.StreamConfig(rate=1e7))
         else:
             sender = spead2.send.UdpStream(
                 thread_pool, send_sock,
@@ -383,10 +386,11 @@ class TestPassthroughUdpMulticast(BaseTestPassthroughSubstreams):
 
     def prepare_senders(self, thread_pool, n):
         if n == 1:
-            return spead2.send.UdpStream(
-                thread_pool, self.MCAST_GROUP, 8887,
-                spead2.send.StreamConfig(rate=1e7),
-                buffer_size=0, ttl=1, interface_address=self.INTERFACE_ADDRESS)
+            with pytest.deprecated_call():
+                return spead2.send.UdpStream(
+                    thread_pool, self.MCAST_GROUP, 8887,
+                    spead2.send.StreamConfig(rate=1e7),
+                    buffer_size=0, ttl=1, interface_address=self.INTERFACE_ADDRESS)
         else:
             return spead2.send.UdpStream(
                 thread_pool,
@@ -415,10 +419,11 @@ class TestPassthroughUdp6Multicast(TestPassthroughUdp6):
     def prepare_senders(self, thread_pool, n):
         interface_index = self.get_interface_index()
         if n == 1:
-            return spead2.send.UdpStream(
-                thread_pool, self.MCAST_GROUP, 8887,
-                spead2.send.StreamConfig(rate=1e7),
-                buffer_size=0, ttl=0, interface_index=interface_index)
+            with pytest.deprecated_call():
+                return spead2.send.UdpStream(
+                    thread_pool, self.MCAST_GROUP, 8887,
+                    spead2.send.StreamConfig(rate=1e7),
+                    buffer_size=0, ttl=0, interface_index=interface_index)
         else:
             return spead2.send.UdpStream(
                 thread_pool,
@@ -495,7 +500,8 @@ class TestPassthroughTcp6(BaseTestPassthrough):
         receiver.add_tcp_reader(8887, bind_hostname="::1")
 
     def prepare_sender(self, thread_pool):
-        return spead2.send.TcpStream(thread_pool, "::1", 8887)
+        with pytest.deprecated_call():
+            return spead2.send.TcpStream(thread_pool, "::1", 8887)
 
 
 class TestPassthroughMem(BaseTestPassthrough):
@@ -526,7 +532,8 @@ class TestPassthroughInproc(BaseTestPassthroughSubstreams):
     def prepare_senders(self, thread_pool, n):
         assert n == len(self._queues)
         if n == 1:
-            return spead2.send.InprocStream(thread_pool, self._queues[0])
+            with pytest.deprecated_call():
+                return spead2.send.InprocStream(thread_pool, self._queues[0])
         else:
             return spead2.send.InprocStream(thread_pool, self._queues)
 

--- a/spead2/test/test_passthrough_asyncio.py
+++ b/spead2/test/test_passthrough_asyncio.py
@@ -18,8 +18,6 @@
 import socket
 import asyncio
 
-from nose.tools import assert_equal
-
 import spead2
 import spead2.send
 import spead2.recv.asyncio
@@ -36,7 +34,6 @@ class BaseTestPassthroughAsync(test_passthrough.BaseTestPassthrough):
                 self.transmit_item_groups_async(item_groups, memcpy, allocator, new_order))
         finally:
             loop.close()
-        return ret
 
     async def transmit_item_groups_async(self, item_groups, memcpy, allocator, new_order='='):
         if self.requires_ipv6:
@@ -77,12 +74,12 @@ class BaseTestPassthroughAsync(test_passthrough.BaseTestPassthrough):
 
     async def prepare_receivers(self, receivers):
         """Generate receivers to use in the test."""
-        assert_equal(1, len(receivers))
+        assert len(receivers) == 1
         await self.prepare_receiver(receivers[0])
 
     async def prepare_senders(self, thread_pool, n):
         """Generate a sender to use in the test, with `n` substreams."""
-        assert_equal(1, n)
+        assert n == 1
         return await self.prepare_sender(thread_pool)
 
 

--- a/spead2/test/test_passthrough_asyncio.py
+++ b/spead2/test/test_passthrough_asyncio.py
@@ -18,6 +18,8 @@
 import socket
 import asyncio
 
+import pytest
+
 import spead2
 import spead2.send
 import spead2.recv.asyncio
@@ -99,10 +101,11 @@ class TestPassthroughUdp(BaseTestPassthroughSubstreamsAsync):
 
     async def prepare_senders(self, thread_pool, n):
         if n == 1:
-            return spead2.send.asyncio.UdpStream(
-                thread_pool, "localhost", 8888,
-                spead2.send.StreamConfig(rate=1e7),
-                buffer_size=0)
+            with pytest.deprecated_call():
+                return spead2.send.asyncio.UdpStream(
+                    thread_pool, "localhost", 8888,
+                    spead2.send.StreamConfig(rate=1e7),
+                    buffer_size=0)
         else:
             return spead2.send.asyncio.UdpStream(
                 thread_pool,
@@ -124,9 +127,10 @@ class TestPassthroughUdpCustomSocket(BaseTestPassthroughSubstreamsAsync):
     async def prepare_senders(self, thread_pool, n):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         if n == 1:
-            stream = spead2.send.asyncio.UdpStream(
-                thread_pool, sock, '127.0.0.1', self._ports[0],
-                spead2.send.StreamConfig(rate=1e7))
+            with pytest.deprecated_call():
+                stream = spead2.send.asyncio.UdpStream(
+                    thread_pool, sock, '127.0.0.1', self._ports[0],
+                    spead2.send.StreamConfig(rate=1e7))
         else:
             stream = spead2.send.asyncio.UdpStream(
                 thread_pool, sock,
@@ -142,7 +146,7 @@ class TestPassthroughTcp(BaseTestPassthroughAsync):
 
     async def prepare_sender(self, thread_pool):
         sender = await spead2.send.asyncio.TcpStream.connect(
-            thread_pool, "127.0.0.1", 8888)
+            thread_pool, [("127.0.0.1", 8888)])
         return sender
 
 
@@ -175,7 +179,8 @@ class TestPassthroughInproc(BaseTestPassthroughSubstreamsAsync):
     async def prepare_senders(self, thread_pool, n):
         assert n == len(self._queues)
         if n == 1:
-            return spead2.send.asyncio.InprocStream(thread_pool, self._queues[0])
+            with pytest.deprecated_call():
+                return spead2.send.asyncio.InprocStream(thread_pool, self._queues[0])
         else:
             return spead2.send.asyncio.InprocStream(thread_pool, self._queues)
 

--- a/spead2/test/test_recv.py
+++ b/spead2/test/test_recv.py
@@ -179,7 +179,7 @@ FLAVOUR = Flavour(48)
 class TestDecode:
     """Various types of descriptors must be correctly interpreted to decode data"""
 
-    def __init__(self):
+    def setup(self):
         self.flavour = FLAVOUR
 
     def data_to_heaps(self, data, **kwargs):
@@ -795,9 +795,9 @@ class TestRingStreamConfig:
 
 
 class TestStream:
-    """Tests for the stream API"""
+    """Tests for the stream API."""
 
-    def __init__(self):
+    def setup(self):
         self.flavour = FLAVOUR
 
     def test_full_stop(self):

--- a/spead2/test/test_recv_asyncio.py
+++ b/spead2/test/test_recv_asyncio.py
@@ -1,4 +1,4 @@
-# Copyright 2018 SKA South Africa
+# Copyright 2018, 2020 SKA South Africa
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -13,19 +13,19 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import asynctest
-from nose.tools import assert_equal, assert_true
+import pytest
 
 import spead2
 import spead2.send
 import spead2.recv.asyncio
 
 
-class TestRecvAsyncio(asynctest.TestCase):
+@pytest.mark.asyncio
+class TestRecvAsyncio:
     async def test_async_iter(self):
         tp = spead2.ThreadPool()
         queue = spead2.InprocQueue()
-        sender = spead2.send.InprocStream(tp, queue)
+        sender = spead2.send.InprocStream(tp, [queue])
         ig = spead2.send.ItemGroup()
         sender.send_heap(ig.get_start())
         sender.send_heap(ig.get_end())
@@ -36,6 +36,6 @@ class TestRecvAsyncio(asynctest.TestCase):
         receiver.add_inproc_reader(queue)
         async for heap in receiver:
             heaps.append(heap)
-        assert_equal(2, len(heaps))
-        assert_true(heaps[0].is_start_of_stream())
-        assert_true(heaps[1].is_end_of_stream())
+        assert len(heaps) == 2
+        assert heaps[0].is_start_of_stream()
+        assert heaps[1].is_end_of_stream()

--- a/spead2/test/test_send.py
+++ b/spead2/test/test_send.py
@@ -110,7 +110,7 @@ def offset_generator(fields):
 class TestEncode:
     """Test heap encoding of various data"""
 
-    def __init__(self):
+    def setup(self):
         self.flavour = Flavour(4, 64, 48, 0)
 
     def test_empty(self):

--- a/spead2/test/test_send.py
+++ b/spead2/test/test_send.py
@@ -522,7 +522,7 @@ class TestStream:
         # Create a stream with a packet size that is bigger than the likely
         # MTU. It should cause an error.
         stream = send.UdpStream(
-            spead2.ThreadPool(), "localhost", 8888,
+            spead2.ThreadPool(), [("localhost", 8888)],
             send.StreamConfig(max_packet_size=100000), buffer_size=0)
         with pytest.raises(IOError):
             stream.send_heap(self.heap)
@@ -569,14 +569,14 @@ class TestStream:
 class TestTcpStream:
     def test_failed_connect(self):
         with pytest.raises(IOError):
-            send.TcpStream(spead2.ThreadPool(), '127.0.0.1', 8887)
+            send.TcpStream(spead2.ThreadPool(), [('127.0.0.1', 8887)])
 
 
 class TestInprocStream:
     def setup(self):
         self.flavour = Flavour(4, 64, 48, 0)
         self.queue = spead2.InprocQueue()
-        self.stream = send.InprocStream(spead2.ThreadPool(), self.queue)
+        self.stream = send.InprocStream(spead2.ThreadPool(), [self.queue])
 
     def test_stopped_queue(self):
         self.queue.stop()

--- a/spead2/test/test_send_asyncio.py
+++ b/spead2/test/test_send_asyncio.py
@@ -1,4 +1,4 @@
-# Copyright 2015, 2019 SKA South Africa
+# Copyright 2015, 2019-2020 SKA South Africa
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -16,7 +16,7 @@
 import asyncio
 
 import numpy as np
-from nose.tools import assert_greater, assert_equal, assert_raises
+import pytest
 
 import spead2
 import spead2.send
@@ -24,58 +24,50 @@ import spead2.send.asyncio
 from spead2.send.asyncio import UdpStream
 
 
+@pytest.mark.asyncio
 class TestUdpStream:
     def setup(self):
         # Make a stream slow enough that we can test async interactions
         config = spead2.send.StreamConfig(rate=5e6)
-        self.stream = UdpStream(spead2.ThreadPool(), 'localhost', 8888, config)
+        self.stream = UdpStream(spead2.ThreadPool(), [('localhost', 8888)], config)
         self.ig = spead2.send.ItemGroup()
         self.ig.add_item(0x1000, 'test', 'Test item', shape=(256 * 1024,), dtype=np.uint8)
         self.ig['test'].value = np.zeros((256 * 1024,), np.uint8)
         self.heap = self.ig.get_heap()
 
     async def _test_async_flush(self):
-        assert_greater(self.stream._active, 0)
+        assert self.stream._active > 0
         await self.stream.async_flush()
-        assert_equal(self.stream._active, 0)
+        assert self.stream._active == 0
 
-    def test_async_flush(self):
+    async def test_async_flush(self):
         for i in range(3):
             asyncio.ensure_future(self.stream.async_send_heap(self.heap))
-        # The above only queues up the async sends on the event loop. The rest of the
-        # test needs to be run from inside the event loop
-        asyncio.get_event_loop().run_until_complete(self._test_async_flush())
+        await self._test_async_flush()
 
-    def test_async_flush_fail(self):
+    async def test_async_flush_fail(self):
         """Test async_flush in the case that the last heap sent failed.
+
         This is arranged by filling up the queue slots first.
         """
         for i in range(5):
             asyncio.ensure_future(self.stream.async_send_heap(self.heap))
-        # The above only queues up the async sends on the event loop. The rest of the
-        # test needs to be run from inside the event loop
-        asyncio.get_event_loop().run_until_complete(self._test_async_flush())
+        await self._test_async_flush()
 
-    async def _test_send_error(self, future):
-        with assert_raises(IOError):
-            await future
-
-    def test_send_error(self):
+    async def test_send_error(self):
         """An error in sending must be reported through the future."""
         # Create a stream with a packet size that is bigger than the likely
         # MTU. It should cause an error.
         stream = UdpStream(
-            spead2.ThreadPool(), "localhost", 8888,
+            spead2.ThreadPool(), [("localhost", 8888)],
             spead2.send.StreamConfig(max_packet_size=100000), buffer_size=0)
-        future = stream.async_send_heap(self.heap)
-        asyncio.get_event_loop().run_until_complete(self._test_send_error(future))
+        with pytest.raises(IOError):
+            await stream.async_send_heap(self.heap)
 
 
+@pytest.mark.asyncio
 class TestTcpStream:
-    async def _test_connect_failed(self):
+    async def test_connect_failed(self):
         thread_pool = spead2.ThreadPool()
-        with assert_raises(IOError):
-            await spead2.send.asyncio.TcpStream.connect(thread_pool, '127.0.0.1', 8887)
-
-    def test_connect_failed(self):
-        asyncio.get_event_loop().run_until_complete(self._test_connect_failed())
+        with pytest.raises(IOError):
+            await spead2.send.asyncio.TcpStream.connect(thread_pool, [('127.0.0.1', 8887)])


### PR DESCRIPTION
This is a relatively lightweight conversion, mainly to move from asynctest (which doesn't seem to be maintained) to pytest-asyncio. Unittest assertions are replaced by assertion statements, but the class structure is still in place even though a lot of it would be more gracefully handled by parametrisation and fixtures.

The directory structure is also not changed, and that causes some problems with pytest testing the local source tree rather than the installed version. I'll fix that in a follow-up PR so that I'm not mixing code changes with renames.