### PR TITLE
Add support for zero-copy send with ibverbs

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,6 +10,8 @@ Other changes:
 
 - Support multiple "substreams" in a send stream (see :ref:`py-substreams`).
 - Reduce overhead for dealing with incomplete heaps.
+- Allow ibverbs senders to register memory regions for zero-copy
+  transmission.
 - Add C++ preprocessor defines for the version number.
 - Drop support for Python 3.5, which is end-of-life.
 - Change code examples to use standard SPEAD rather than PySPEAD bug
@@ -20,8 +22,10 @@ Other changes:
 - :cpp:class:`spead2::send::stream::flush` now only blocks until the
   previously enqueued heaps are completed. Another thread that keeps adding
   heaps would previously have prevented it from returning.
-- The sending infrastructure has been partially rewritten, resulting in
-  performance improvements, in some cases of over 10%.
+- Partially rewrite the sending infrastructure, resulting in performance
+  improvements, in some cases of over 10%.
+- Setting a buffer size of 0 for a :py:class:`~spead2.send.UdpIbvStream` now
+  uses the default buffer size, instead of a 1-packet buffer.
 
 Additionally, refer to the changes for 3.0.0b1 below.
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -26,6 +26,7 @@ Other changes:
   improvements, in some cases of over 10%.
 - Setting a buffer size of 0 for a :py:class:`~spead2.send.UdpIbvStream` now
   uses the default buffer size, instead of a 1-packet buffer.
+- Fix :program:`spead2_bench.py` ignoring the :opt:`--send-affinity` option.
 
 Additionally, refer to the changes for 3.0.0b1 below.
 

--- a/doc/cpp-ibverbs.rst
+++ b/doc/cpp-ibverbs.rst
@@ -9,6 +9,7 @@ the :cpp:class:`spead2::recv::udp_ibv_reader` and
    :members: udp_ibv_reader
 
 .. doxygenclass:: spead2::send::udp_ibv_stream_config
+   :members:
 
 .. doxygenclass:: spead2::send::udp_ibv_stream
    :members: udp_ibv_stream

--- a/doc/cpp-ibverbs.rst
+++ b/doc/cpp-ibverbs.rst
@@ -8,5 +8,7 @@ the :cpp:class:`spead2::recv::udp_ibv_reader` and
 .. doxygenclass:: spead2::recv::udp_ibv_reader
    :members: udp_ibv_reader
 
+.. doxygenclass:: spead2::send::udp_ibv_stream_config
+
 .. doxygenclass:: spead2::send::udp_ibv_stream
    :members: udp_ibv_stream

--- a/doc/migrate-3.rst
+++ b/doc/migrate-3.rst
@@ -72,6 +72,14 @@ a "fluent" style e.g.:
 
    spead2::send::stream_config().set_max_packet_size(9172).set_rate(1e6)
 
+For :ref:`py-ibverbs` ibverbs streams the changes are more significant. There
+is now a :py:class:`spead2.send.UdpIbvStreamConfig` class that works similarly
+to :py:class:`spead2.send.StreamConfig`, but configures properties specific to
+the ibverbs stream. The old constructor is still available (but deprecated);
+however, the constants :py:data:`.UdpIbvStream.DEFAULT_BUFFER_SIZE` and
+:py:data:`.UdpIbvStream.DEFAULT_MAX_POLL` have moved to the
+:class:`~spead2.send.UdpIbvStreamConfig` class.
+
 Substreams
 ----------
 A new feature is the ability to create a send stream with multiple destinations

--- a/doc/migrate-3.rst
+++ b/doc/migrate-3.rst
@@ -72,7 +72,7 @@ a "fluent" style e.g.:
 
    spead2::send::stream_config().set_max_packet_size(9172).set_rate(1e6)
 
-For :ref:`py-ibverbs` ibverbs streams the changes are more significant. There
+For :doc:`ibverbs <py-ibverbs>` streams the changes are more significant. There
 is now a :py:class:`spead2.send.UdpIbvStreamConfig` class that works similarly
 to :py:class:`spead2.send.StreamConfig`, but configures properties specific to
 the ibverbs stream. The old constructor is still available (but deprecated);

--- a/doc/py-ibverbs.rst
+++ b/doc/py-ibverbs.rst
@@ -160,9 +160,9 @@ configuration:
 
    The constructor arguments are also instance attributes. Note that
    they are implemented as properties that return copies of the state, which
-   means that modifying `endpoints` or `memory_regions` will not have any
-   effect as only the copy will be modified. The entire list must be assigned
-   to update it.
+   means that mutating `endpoints` or `memory_regions` (for example, with
+   :py:meth:`~list.append`) will not have any effect as only the copy will be
+   modified. The entire list must be assigned to update it.
 
 .. py:class:: spead2.send.UdpIbvStream(thread_pool, config, udp_ibv_config)
 

--- a/doc/py-ibverbs.rst
+++ b/doc/py-ibverbs.rst
@@ -127,21 +127,17 @@ of :py:class:`spead2.send.UdpStream`. It has a different constructor, but the
 same methods. There is also a :py:class:`spead2.send.asyncio.UdpIbvStream`
 class, analogous to :py:class:`spead2.send.asyncio.UdpStream`.
 
-.. py:class:: spead2.send.UdpIbvStream(thread_pool, endpoints, config, interface_address, buffer_size, ttl=1, comp_vector=0, max_poll=DEFAULT_MAX_POLL)
+There is an additional configuration class for ibverbs-specific
+configuration:
 
-   Create a multicast IPv4 UDP stream using the ibverbs API
+.. py:class:: spead2.send.UdpIbvStreamConfig(*, endpoints=[], interface_address='', buffer_size=DEFAULT_BUFFER_SIZE, ttl=1, comp_vector=0, max_poll=DEFAULT_MAX_POLL, memory_regions=[])
 
-   :param thread_pool: Thread pool handling the I/O
-   :type thread_pool: :py:class:`spead2.ThreadPool`
    :param List[Tuple[str, int]] endpoints: Peer endpoints (one per substream)
-   :param config: Stream configuration
-   :type config: :py:class:`spead2.send.StreamConfig`
    :param str interface_address: Hostname/IP address of the interface which
      will be subscribed
-   :param int buffer_size: Socket buffer size. A warning is logged if this
-     size cannot be set due to OS limits.
-   :param int ttl: Multicast TTL
    :param int buffer_size: Requested memory allocation for work requests.
+     It may be adjusted to an integer number of packets.
+   :param int ttl: Multicast TTL
    :param int comp_vector: Completion channel vector (interrupt)
      for asynchronous operation, or
      a negative value to poll continuously. Polling
@@ -156,3 +152,25 @@ class, analogous to :py:class:`spead2.send.asyncio.UdpStream`.
      waiting for an interrupt (if `comp_vector` is
      non-negative) or letting other code run on the
      thread (if `comp_vector` is negative).
+   :param List[object] memory_regions: Objects implementing the buffer
+     protocol that will be used to hold item data. This is not required, but
+     data stored in these buffers may be transmitted directly without
+     requiring a copy, yielding higher performance. There may be
+     platform-specific limitations on the size and number of these buffers.
+
+   The constructor arguments are also instance attributes. Note that
+   they are implemented as properties that return copies of the state, which
+   means that modifying `endpoints` or `memory_regions` will not have any
+   effect as only the copy will be modified. The entire list must be assigned
+   to update it.
+
+.. py:class:: spead2.send.UdpIbvStream(thread_pool, config, udp_ibv_config)
+
+   Create a multicast IPv4 UDP stream using the ibverbs API
+
+   :param thread_pool: Thread pool handling the I/O
+   :type thread_pool: :py:class:`spead2.ThreadPool`
+   :param config: Stream configuration
+   :type config: :py:class:`spead2.send.StreamConfig`
+   :param udp_ibv_config: Additional stream configuration
+   :type udp_ibv_config: :py:class:`spead2.send.UdpIbvStreamConfig`

--- a/doc/py-send.rst
+++ b/doc/py-send.rst
@@ -149,7 +149,8 @@ substream (for backwards compatibility).
 
    :param thread_pool: Thread pool handling the I/O
    :type thread_pool: :py:class:`spead2.ThreadPool`
-   :param List[Tuple[str, int]] endpoints: Peer endpoints (one per substream)
+   :param endpoints: Peer endpoints (one per substream)
+   :type endpoints: List[Tuple[str, int]]
    :param config: Stream configuration
    :type config: :py:class:`spead2.send.StreamConfig`
    :param int buffer_size: Socket buffer size. A warning is logged if this

--- a/include/spead2/common_ibv.h
+++ b/include/spead2/common_ibv.h
@@ -142,6 +142,8 @@ class rdma_event_channel_t : public std::unique_ptr<rdma_event_channel, detail::
 {
 public:
     rdma_event_channel_t();
+    // Allow explicitly creating an uninitialized unique_ptr
+    rdma_event_channel_t(std::nullptr_t) {}
 };
 
 class rdma_cm_id_t : public std::unique_ptr<rdma_cm_id, detail::rdma_cm_id_deleter>

--- a/include/spead2/common_raw_packet.h
+++ b/include/spead2/common_raw_packet.h
@@ -93,8 +93,8 @@ public:
     packet_buffer(void *ptr, std::size_t length);
     operator boost::asio::mutable_buffer() const;
 
-    std::uint8_t *data() const;
-    std::size_t size() const;
+    std::uint8_t *data() const { return ptr; }
+    std::size_t size() const { return length; }
 };
 
 #define SPEAD2_DECLARE_FIELD(offset, type, name, transform) \

--- a/include/spead2/py_common.h
+++ b/include/spead2/py_common.h
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2017 SKA South Africa
+/* Copyright 2015, 2017, 2020 SKA South Africa
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -235,7 +235,7 @@ public:
 };
 
 // Like pybind11::buffer::request, but allows extra flags to be passed
-pybind11::buffer_info request_buffer_info(pybind11::buffer &buffer, int extra_flags);
+pybind11::buffer_info request_buffer_info(const pybind11::buffer &buffer, int extra_flags);
 
 void register_module(pybind11::module m);
 

--- a/include/spead2/send_packet.h
+++ b/include/spead2/send_packet.h
@@ -44,7 +44,8 @@ class heap;
  *
  * @todo Investigate whether number of new calls could be reduced by using
  * a pool for the case of packets with no item pointers other than the
- * per-packet ones.
+ * per-packet ones; or by having the caller of the packet_generator provide
+ * storage.
  */
 struct packet
 {

--- a/include/spead2/send_udp_ibv.h
+++ b/include/spead2/send_udp_ibv.h
@@ -73,7 +73,7 @@ public:
     /// Get the configured endpoints
     const std::vector<boost::asio::ip::udp::endpoint> &get_endpoints() const { return endpoints; }
     /**
-     * Set all endpoints at once. Each endpoint corresponds to a substream.
+     * Set the endpoints (replacing any previous). Each endpoint corresponds to a substream.
      *
      * @throws std::invalid_argument if any element of @a endpoints is not an IPv4 multicast address.
      */

--- a/include/spead2/send_udp_ibv.h
+++ b/include/spead2/send_udp_ibv.h
@@ -47,13 +47,18 @@ class udp_ibv_stream_config
 public:
     typedef std::pair<const void *, std::size_t> memory_region;
 
+    /// Default send buffer size
+    static constexpr std::size_t default_buffer_size = 512 * 1024;
+    /// Default number of times to poll in a row
+    static constexpr int default_max_poll = 10;
+
 private:
     std::vector<boost::asio::ip::udp::endpoint> endpoints;
     boost::asio::ip::address interface_address;
-    std::size_t buffer_size;
-    std::uint8_t ttl;
-    int comp_vector;
-    int max_poll;
+    std::size_t buffer_size = default_buffer_size;
+    std::uint8_t ttl = 1;
+    int comp_vector = 0;
+    int max_poll = default_max_poll;
     std::vector<memory_region> memory_regions;
 
 public:
@@ -151,11 +156,6 @@ public:
 class udp_ibv_stream : public stream
 {
 public:
-    /// Default send buffer size, if none is passed to the constructor
-    static constexpr std::size_t default_buffer_size = 512 * 1024;
-    /// Number of times to poll in a row, if none is explicitly passed to the constructor
-    static constexpr int default_max_poll = 10;
-
     /**
      * Backwards-compatibility constructor (taking only a single endpoint).
      *
@@ -170,10 +170,10 @@ public:
         const boost::asio::ip::udp::endpoint &endpoint,
         const stream_config &config,
         const boost::asio::ip::address &interface_address,
-        std::size_t buffer_size = default_buffer_size,
+        std::size_t buffer_size = udp_ibv_stream_config::default_buffer_size,
         int ttl = 1,
         int comp_vector = 0,
-        int max_poll = default_max_poll);
+        int max_poll = udp_ibv_stream_config::default_max_poll);
 
     /**
      * Constructor.

--- a/include/spead2/send_udp_ibv.h
+++ b/include/spead2/send_udp_ibv.h
@@ -29,6 +29,7 @@
 
 #include <boost/asio.hpp>
 #include <vector>
+#include <utility>
 #include <initializer_list>
 #include <spead2/send_stream.h>
 #include <spead2/common_thread_pool.h>
@@ -37,6 +38,48 @@ namespace spead2
 {
 namespace send
 {
+
+class udp_ibv_stream_config
+{
+public:
+    typedef std::pair<const void *, std::size_t> memory_region;
+
+private:
+    std::vector<boost::asio::ip::udp::endpoint> endpoints;
+    boost::asio::ip::address interface_address;
+    std::size_t buffer_size;
+    std::uint8_t ttl;
+    int comp_vector;
+    int max_poll;
+    std::vector<memory_region> memory_regions;
+
+public:
+    udp_ibv_stream_config();
+
+    // TODO: document all of these
+    const std::vector<boost::asio::ip::udp::endpoint> &get_endpoints() const { return endpoints; }
+    udp_ibv_stream_config &set_endpoints(const std::vector<boost::asio::ip::udp::endpoint> &endpoints);
+    udp_ibv_stream_config &add_endpoint(const boost::asio::ip::udp::endpoint &endpoint);
+
+    const boost::asio::ip::address get_interface_address() const { return interface_address; }
+    udp_ibv_stream_config &set_interface_address(const boost::asio::ip::address &interface_address);
+
+    std::size_t get_buffer_size() const { return buffer_size; }
+    udp_ibv_stream_config &set_buffer_size(std::size_t buffer_size);
+
+    std::uint8_t get_ttl() const { return ttl; }
+    udp_ibv_stream_config &set_ttl(std::uint8_t ttl);
+
+    int get_comp_vector() const { return comp_vector; }
+    udp_ibv_stream_config &set_comp_vector(int comp_vector);
+
+    int get_max_poll() const { return max_poll; }
+    udp_ibv_stream_config &set_max_poll(int max_poll);
+
+    const std::vector<memory_region> &get_memory_regions() const { return memory_regions; }
+    udp_ibv_stream_config &set_memory_regions(const std::vector<memory_region> &memory_regions);
+    udp_ibv_stream_config &add_memory_region(const void *ptr, std::size_t size);
+};
 
 class udp_ibv_stream : public stream
 {
@@ -72,7 +115,7 @@ public:
      * @throws std::invalid_argument if @a endpoint is not an IPv4 multicast address
      * @throws std::invalid_argument if @a interface_address is not an IPv4 address
      */
-    SPEAD2_DEPRECATED("use a vector of endpoints")
+    SPEAD2_DEPRECATED("use udp_ibv_stream_config")
     udp_ibv_stream(
         io_service_ref io_service,
         const boost::asio::ip::udp::endpoint &endpoint,
@@ -87,50 +130,15 @@ public:
      * Constructor.
      *
      * @param io_service   I/O service for sending data
-     * @param endpoints    Multicast groups and ports
-     * @param config       Stream configuration
-     * @param interface_address   Address of the outgoing interface
-     * @param buffer_size  Socket buffer size (0 for OS default)
-     * @param ttl          Maximum number of hops
-     * @param comp_vector  Completion channel vector (interrupt) for asynchronous operation, or
-     *                     a negative value to poll continuously. Polling
-     *                     should not be used if there are other users of the
-     *                     thread pool. If a non-negative value is provided, it
-     *                     is taken modulo the number of available completion
-     *                     vectors. This allows a number of readers to be
-     *                     assigned sequential completion vectors and have them
-     *                     load-balanced, without concern for the number
-     *                     available.
-     * @param max_poll     Maximum number of times to poll in a row, without
-     *                     waiting for an interrupt (if @a comp_vector is
-     *                     non-negative) or letting other code run on the
-     *                     thread (if @a comp_vector is negative).
+     * @param config       Common stream configuration
+     * @param udp_ibv_config  Class-specific stream configuration
      *
-     * @throws std::invalid_argument if @a endpoint is not an IPv4 multicast address
-     * @throws std::invalid_argument if @a interface_address is not an IPv4 address
+     * @throws std::invalid_argument if udp_ibv_config does not have all fields set.
      */
     udp_ibv_stream(
         io_service_ref io_service,
-        const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
         const stream_config &config,
-        const boost::asio::ip::address &interface_address,
-        std::size_t buffer_size = default_buffer_size,
-        int ttl = 1,
-        int comp_vector = 0,
-        int max_poll = default_max_poll);
-
-    /* Force an initializer list to forward to the vector version (without this,
-     * a singleton initializer list forwards to the scalar version).
-     */
-    udp_ibv_stream(
-        io_service_ref io_service,
-        std::initializer_list<boost::asio::ip::udp::endpoint> endpoints,
-        const stream_config &config,
-        const boost::asio::ip::address &interface_address,
-        std::size_t buffer_size = default_buffer_size,
-        int ttl = 1,
-        int comp_vector = 0,
-        int max_poll = default_max_poll);
+        const udp_ibv_stream_config &udp_ibv_config);
 };
 
 } // namespace send

--- a/src/common_ibv.cpp
+++ b/src/common_ibv.cpp
@@ -376,7 +376,7 @@ ibv_qp_t::ibv_qp_t(const rdma_cm_id_t &cm_id, ibv_qp_init_attr_ex *init_attr)
 ibv_mr_t::ibv_mr_t(const ibv_pd_t &pd, void *addr, std::size_t length, int access)
 {
     errno = 0;
-    ibv_mr * mr = ibv_reg_mr(pd.get(), addr, length, IBV_ACCESS_LOCAL_WRITE);
+    ibv_mr * mr = ibv_reg_mr(pd.get(), addr, length, access);
     if (!mr)
         throw_errno("ibv_reg_mr failed");
     reset(mr);

--- a/src/common_raw_packet.cpp
+++ b/src/common_raw_packet.cpp
@@ -153,16 +153,6 @@ packet_buffer::packet_buffer(void *ptr, std::size_t size)
 {
 }
 
-std::uint8_t *packet_buffer::data() const
-{
-    return ptr;
-}
-
-std::size_t packet_buffer::size() const
-{
-    return length;
-}
-
 packet_buffer::operator boost::asio::mutable_buffer() const
 {
     return boost::asio::mutable_buffer(ptr, length);

--- a/src/py_common.cpp
+++ b/src/py_common.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2017 SKA South Africa
+/* Copyright 2015, 2017, 2020 SKA South Africa
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -122,7 +122,7 @@ void thread_pool_wrapper::stop()
     thread_pool::stop();
 }
 
-py::buffer_info request_buffer_info(py::buffer &buffer, int extra_flags)
+py::buffer_info request_buffer_info(const py::buffer &buffer, int extra_flags)
 {
     std::unique_ptr<Py_buffer> view(new Py_buffer);
     int flags = PyBUF_STRIDES | PyBUF_FORMAT | extra_flags;

--- a/src/py_send.cpp
+++ b/src/py_send.cpp
@@ -404,7 +404,7 @@ public:
 #if SPEAD2_USE_IBV
 
 /* Managing the endpoint and memory region lists requires some sleight of
- * hand. We store a separate code in the wrapper in a Python-centric format.
+ * hand. We store a separate copy in the wrapper in a Python-centric format.
  * When constructing the stream, we make a copy with the C++ view.
  */
 class udp_ibv_stream_config_wrapper : public udp_ibv_stream_config

--- a/src/py_send.cpp
+++ b/src/py_send.cpp
@@ -569,6 +569,7 @@ static py::class_<T> udp_ibv_stream_register(py::module &m, const char *name)
                         buffer_infos.back().ptr,
                         buffer_infos.back().itemsize * buffer_infos.back().size);
                 }
+                udp_ibv_config.set_memory_regions(regions);
 
                 return new T(std::move(thread_pool), config, udp_ibv_config, std::move(buffer_infos));
             }),

--- a/src/py_send.cpp
+++ b/src/py_send.cpp
@@ -542,10 +542,10 @@ static py::class_<T> udp_ibv_stream_register(py::module &m, const char *name)
              "thread_pool"_a, "multicast_group"_a, "port"_a,
              "config"_a = stream_config(),
              "interface_address"_a,
-             "buffer_size"_a = T::default_buffer_size,
+             "buffer_size"_a = udp_ibv_stream_config::default_buffer_size,
              "ttl"_a = 1,
              "comp_vector"_a = 0,
-             "max_poll"_a = T::default_max_poll)
+             "max_poll"_a = udp_ibv_stream_config::default_max_poll)
         .def(py::init([](std::shared_ptr<thread_pool_wrapper> thread_pool,
                          const stream_config &config,
                          udp_ibv_stream_config_wrapper &udp_ibv_config_wrapper)
@@ -575,9 +575,7 @@ static py::class_<T> udp_ibv_stream_register(py::module &m, const char *name)
             }),
             "thread_pool"_a,
             "config"_a = stream_config(),
-            "udp_ibv_config"_a)
-        .def_readonly_static("DEFAULT_BUFFER_SIZE", &T::default_buffer_size)
-        .def_readonly_static("DEFAULT_MAX_POLL", &T::default_max_poll);
+            "udp_ibv_config"_a);
 }
 #endif
 
@@ -886,7 +884,10 @@ py::module register_module(py::module &parent)
                       SPEAD2_PTMF_VOID(udp_ibv_stream_config_wrapper, set_comp_vector))
         .def_property("max_poll",
                       SPEAD2_PTMF(udp_ibv_stream_config_wrapper, get_max_poll),
-                      SPEAD2_PTMF_VOID(udp_ibv_stream_config_wrapper, set_max_poll));
+                      SPEAD2_PTMF_VOID(udp_ibv_stream_config_wrapper, set_max_poll))
+        .def_readonly_static("DEFAULT_BUFFER_SIZE", &udp_ibv_stream_config_wrapper::default_buffer_size)
+        .def_readonly_static("DEFAULT_MAX_POLL", &udp_ibv_stream_config_wrapper::default_max_poll);
+
     {
         auto stream_class = udp_ibv_stream_register<udp_ibv_stream_wrapper<stream_wrapper<udp_ibv_stream>>>(m, "UdpIbvStream");
         sync_stream_register(stream_class);

--- a/src/py_send.cpp
+++ b/src/py_send.cpp
@@ -548,7 +548,7 @@ static py::class_<T> udp_ibv_stream_register(py::module &m, const char *name)
              "max_poll"_a = udp_ibv_stream_config::default_max_poll)
         .def(py::init([](std::shared_ptr<thread_pool_wrapper> thread_pool,
                          const stream_config &config,
-                         udp_ibv_stream_config_wrapper &udp_ibv_config_wrapper)
+                         const udp_ibv_stream_config_wrapper &udp_ibv_config_wrapper)
             {
                 udp_ibv_stream_config udp_ibv_config = udp_ibv_config_wrapper;
                 udp_ibv_config.set_endpoints(

--- a/src/send_udp_ibv.cpp
+++ b/src/send_udp_ibv.cpp
@@ -62,6 +62,12 @@ private:
         ibv_mr_t mr;
 
         memory_region(const ibv_pd_t &pd, const void *ptr, std::size_t size);
+
+        /* Used purely to construct a memory region for comparison e.g. with
+         * std::set<memory_region>::lower_bound. Remove once c++14 is the
+         * minimum version, since it allows types other than the key type for
+         * lower_bound.
+         */
         memory_region(const void *ptr, std::size_t size);
 
         bool operator<(const memory_region &other) const

--- a/src/send_udp_ibv.cpp
+++ b/src/send_udp_ibv.cpp
@@ -452,7 +452,7 @@ udp_ibv_writer::udp_ibv_writer(
     target_batch(calc_target_batch(config, n_slots)),
     socket(get_io_service(), boost::asio::ip::udp::v4()),
     endpoints(udp_ibv_config.get_endpoints()),
-    cm_id(event_channel, nullptr, RDMA_PS_UDP),
+    event_channel(nullptr),
     comp_channel_wrapper(get_io_service()),
     available(n_slots),
     max_poll(udp_ibv_config.get_max_poll())
@@ -478,6 +478,8 @@ udp_ibv_writer::udp_ibv_writer(
     const std::size_t max_raw_size = config.get_max_packet_size() + header_length;
     std::size_t buffer_size = n_slots * max_raw_size;
 
+    event_channel = rdma_event_channel_t();
+    cm_id = rdma_cm_id_t(event_channel, nullptr, RDMA_PS_UDP);
     cm_id.bind_addr(interface_address);
     pd = ibv_pd_t(cm_id);
     int comp_vector = udp_ibv_config.get_comp_vector();

--- a/src/send_udp_ibv.cpp
+++ b/src/send_udp_ibv.cpp
@@ -553,11 +553,10 @@ static void validate_memory_region(const udp_ibv_stream_config::memory_region &r
         throw std::invalid_argument("memory region must have non-zero size");
 }
 
+constexpr std::size_t udp_ibv_stream_config::default_buffer_size;
+constexpr int udp_ibv_stream_config::default_max_poll;
+
 udp_ibv_stream_config::udp_ibv_stream_config()
-    : buffer_size(udp_ibv_stream::default_buffer_size),
-    ttl(1),
-    comp_vector(0),
-    max_poll(udp_ibv_stream::default_max_poll)
 {
 }
 
@@ -590,7 +589,7 @@ udp_ibv_stream_config &udp_ibv_stream_config::set_interface_address(
 udp_ibv_stream_config &udp_ibv_stream_config::set_buffer_size(std::size_t buffer_size)
 {
     if (buffer_size == 0)
-        this->buffer_size = udp_ibv_stream::default_buffer_size;
+        this->buffer_size = default_buffer_size;
     else
         this->buffer_size = buffer_size;
     return *this;
@@ -631,9 +630,6 @@ udp_ibv_stream_config &udp_ibv_stream_config::add_memory_region(const void *ptr,
     memory_regions.push_back(region);
     return *this;
 }
-
-constexpr std::size_t udp_ibv_stream::default_buffer_size;
-constexpr int udp_ibv_stream::default_max_poll;
 
 udp_ibv_stream::udp_ibv_stream(
     io_service_ref io_service,

--- a/src/spead2/send/__init__.py
+++ b/src/spead2/send/__init__.py
@@ -22,7 +22,7 @@ from spead2._spead2.send import (       # noqa: F401
     StreamConfig, Heap, PacketGenerator,
     BytesStream, UdpStream, TcpStream, InprocStream)
 try:
-    from spead2._spead2.send import UdpIbvStream      # noqa: F401
+    from spead2._spead2.send import UdpIbvStream, UdpIbvStreamConfig      # noqa: F401
 except ImportError:
     pass
 

--- a/src/spead2/send/__init__.pyi
+++ b/src/spead2/send/__init__.pyi
@@ -129,11 +129,24 @@ class UdpStream(_UdpStream, _SyncStream):
                  config: StreamConfig = ...) -> None: ...
 
 
-class _UdpIbvStream:
+class UdpIbvStreamConfig:
     DEFAULT_BUFFER_SIZE: ClassVar[int]
     DEFAULT_MAX_POLL: ClassVar[int]
 
-class UdpIbvStream(_UdpIbvStream, _SyncStream):
+    endpoints: _EndpointList
+    interface_address: str
+    buffer_size: int
+    ttl: int
+    comp_vector: int
+    max_poll: int
+    memory_regions: list
+
+    def __init__(self, *, endpoints: _EndpointList = ..., interface_address: str = ...,
+                 buffer_size: int = ..., ttl: int = ..., comp_vector: int = ...,
+                 max_poll: int = ..., memory_regions: list = ...) -> None: ...
+
+
+class UdpIbvStream(_SyncStream):
     @overload
     def __init__(self, thread_pool: spead2.ThreadPool,
                  multicast_group: _PybindStr, port: int,
@@ -144,11 +157,8 @@ class UdpIbvStream(_UdpIbvStream, _SyncStream):
 
     @overload
     def __init__(self, thread_pool: spead2.ThreadPool,
-                 endpoints: _EndpointList,
                  config: StreamConfig,
-                 interface_address: _PybindStr,
-                 buffer_size: int = ..., ttl: int = ...,
-                 comp_vector: int = ..., max_pool: int = ...) -> None: ...
+                 udp_ibv_config: UdpIbvStreamConfig) -> None: ...
 
 
 class _TcpStream:

--- a/src/spead2/send/asyncio.pyi
+++ b/src/spead2/send/asyncio.pyi
@@ -108,7 +108,7 @@ class UdpStream(spead2.send._UdpStream, _AsyncStream):
                  config: spead2.send.StreamConfig = ...,
                  *, loop: Optional[asyncio.AbstractEventLoop] = None) -> None: ...
 
-class UdpIbvStream(spead2.send._UdpIbvStream, _AsyncStream):
+class UdpIbvStream(_AsyncStream):
     @overload
     def __init__(self, thread_pool: spead2.ThreadPool,
                  multicast_group: _PybindStr, port: int,

--- a/src/spead2/tools/bench_asyncio.py
+++ b/src/spead2/tools/bench_asyncio.py
@@ -186,8 +186,16 @@ async def measure_connection_once(args, rate, num_heaps, required_heaps):
         host = args.multicast
     if 'send_ibv' in args and args.send_ibv is not None:
         stream = spead2.send.asyncio.UdpIbvStream(
-            thread_pool, [(host, args.port)], config, args.send_ibv, args.send_buffer,
-            1, args.send_ibv_vector, args.send_ibv_max_poll)
+            thread_pool,
+            config,
+            spead2.send.UdpIbvStreamConfig(
+                endpoints=[(host, args.port)],
+                interface_address=args.send_ibv,
+                buffer_size=args.send_buffer,
+                comp_vector=args.send_ibv_vector,
+                max_poll=args.send_ibv_max_poll
+            )
+        )
     else:
         stream = spead2.send.asyncio.UdpStream(
             thread_pool, [(host, args.port)], config, args.send_buffer)

--- a/src/spead2/tools/bench_asyncio.py
+++ b/src/spead2/tools/bench_asyncio.py
@@ -173,7 +173,14 @@ async def measure_connection_once(args, rate, num_heaps, required_heaps):
         thread_pool = spead2.ThreadPool(1, args.send_affinity[1:] + args.send_affinity[:1])
     else:
         thread_pool = spead2.ThreadPool()
-    thread_pool = spead2.ThreadPool()
+
+    item_group = spead2.send.ItemGroup(
+        flavour=spead2.Flavour(4, 64, args.addr_bits, 0))
+    item_group.add_item(id=None, name='Test item',
+                        description='A test item with arbitrary value',
+                        shape=(args.heap_size,), dtype=np.uint8,
+                        value=np.zeros((args.heap_size,), dtype=np.uint8))
+
     config = spead2.send.StreamConfig(
         max_packet_size=args.packet,
         burst_size=args.burst,
@@ -193,18 +200,13 @@ async def measure_connection_once(args, rate, num_heaps, required_heaps):
                 interface_address=args.send_ibv,
                 buffer_size=args.send_buffer,
                 comp_vector=args.send_ibv_vector,
-                max_poll=args.send_ibv_max_poll
+                max_poll=args.send_ibv_max_poll,
+                memory_regions=[item.value for item in item_group.values()]
             )
         )
     else:
         stream = spead2.send.asyncio.UdpStream(
             thread_pool, [(host, args.port)], config, args.send_buffer)
-    item_group = spead2.send.ItemGroup(
-        flavour=spead2.Flavour(4, 64, args.addr_bits, 0))
-    item_group.add_item(id=None, name='Test item',
-                        description='A test item with arbitrary value',
-                        shape=(args.heap_size,), dtype=np.uint8,
-                        value=np.zeros((args.heap_size,), dtype=np.uint8))
 
     start = timeit.default_timer()
     transferred = await send_stream(item_group, stream, num_heaps, args)

--- a/src/spead2/tools/bench_asyncio.py
+++ b/src/spead2/tools/bench_asyncio.py
@@ -310,7 +310,7 @@ def main():
         group.add_argument('--send-ibv-vector', type=int, default=0, metavar='N',
                            help='Completion vector, or -1 to use polling [%(default)s]')
         group.add_argument('--send-ibv-max-poll', type=int,
-                           default=spead2.send.UdpIbvStream.DEFAULT_MAX_POLL,
+                           default=spead2.send.UdpIbvStreamConfig.DEFAULT_MAX_POLL,
                            help='Maximum number of times to poll in a row [%(default)s]')
     group = master.add_argument_group('receiver options')
     group.add_argument('--recv-affinity', type=spead2.parse_range_list,

--- a/src/spead2/tools/send_asyncio.py
+++ b/src/spead2/tools/send_asyncio.py
@@ -203,7 +203,8 @@ async def async_main():
                 buffer_size=args.buffer,
                 ttl=args.ttl or 1,
                 comp_vector=args.ibv_vector,
-                max_poll=args.ibv_max_poll
+                max_poll=args.ibv_max_poll,
+                memory_regions=[item.value for item in item_group.values()]
             )
         )
     else:

--- a/src/spead2/tools/send_asyncio.py
+++ b/src/spead2/tools/send_asyncio.py
@@ -195,8 +195,17 @@ async def async_main():
             thread_pool, args.destination, config, args.buffer, args.bind)
     elif 'ibv' in args and args.ibv:
         stream = spead2.send.asyncio.UdpIbvStream(
-            thread_pool, args.destination, config, args.bind,
-            args.buffer, args.ttl or 1, args.ibv_vector, args.ibv_max_poll)
+            thread_pool,
+            config,
+            spead2.send.UdpIbvStreamConfig(
+                endpoints=args.destination,
+                interface_address=args.bind,
+                buffer_size=args.buffer,
+                ttl=args.ttl or 1,
+                comp_vector=args.ibv_vector,
+                max_poll=args.ibv_max_poll
+            )
+        )
     else:
         kwargs = {}
         if args.ttl is not None:

--- a/src/spead2/tools/send_asyncio.py
+++ b/src/spead2/tools/send_asyncio.py
@@ -99,7 +99,7 @@ def get_args():
         group.add_argument('--ibv-vector', type=int, default=0, metavar='N',
                            help='Completion vector, or -1 to use polling [%(default)s]')
         group.add_argument('--ibv-max-poll', type=int,
-                           default=spead2.send.UdpIbvStream.DEFAULT_MAX_POLL,
+                           default=spead2.send.UdpIbvStreamConfig.DEFAULT_MAX_POLL,
                            help='Maximum number of times to poll in a row [%(default)s]')
 
     args = parser.parse_args()

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -380,8 +380,14 @@ static std::pair<bool, double> measure_connection_once(
             boost::asio::ip::address interface_address =
                 boost::asio::ip::address::from_string(opts.send_ibv_if);
             stream.reset(new spead2::send::udp_ibv_stream(
-                thread_pool.get_io_service(), {endpoint}, config, interface_address,
-                opts.send_buffer, 1, opts.send_ibv_comp_vector, opts.send_ibv_max_poll));
+                thread_pool.get_io_service(),
+                config,
+                spead2::send::udp_ibv_stream_config()
+                    .set_endpoints({endpoint})
+                    .set_interface_address(interface_address)
+                    .set_buffer_size(opts.send_buffer)
+                    .set_comp_vector(opts.send_ibv_comp_vector)
+                    .set_max_poll(opts.send_ibv_max_poll)));
         }
         else
 #endif

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -73,7 +73,7 @@ struct options
     int send_ibv_comp_vector = 0;
     int send_ibv_max_poll =
 #if SPEAD2_USE_IBV
-        spead2::send::udp_ibv_stream::default_max_poll;
+        spead2::send::udp_ibv_stream_config::default_max_poll;
 #else
         0;
 #endif

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -387,7 +387,8 @@ static std::pair<bool, double> measure_connection_once(
                     .set_interface_address(interface_address)
                     .set_buffer_size(opts.send_buffer)
                     .set_comp_vector(opts.send_ibv_comp_vector)
-                    .set_max_poll(opts.send_ibv_max_poll)));
+                    .set_max_poll(opts.send_ibv_max_poll)
+                    .add_memory_region(data.data(), data.size() * sizeof(data[0]))));
         }
         else
 #endif

--- a/src/spead2_send.cpp
+++ b/src/spead2_send.cpp
@@ -371,9 +371,14 @@ int main(int argc, const char **argv)
         if (opts.ibv)
         {
             stream.reset(new spead2::send::udp_ibv_stream(
-                    io_service, endpoints, config,
-                    interface_address, opts.buffer, opts.ttl,
-                    opts.ibv_comp_vector, opts.ibv_max_poll));
+                    io_service, config,
+                    spead2::send::udp_ibv_stream_config()
+                        .set_endpoints(endpoints)
+                        .set_interface_address(interface_address)
+                        .set_buffer_size(opts.buffer)
+                        .set_ttl(opts.ttl)
+                        .set_comp_vector(opts.ibv_comp_vector)
+                        .set_max_poll(opts.ibv_max_poll)));
         }
         else
 #endif

--- a/src/spead2_send.cpp
+++ b/src/spead2_send.cpp
@@ -61,7 +61,7 @@ struct options
 #if SPEAD2_USE_IBV
     bool ibv = false;
     int ibv_comp_vector = 0;
-    int ibv_max_poll = spead2::send::udp_ibv_stream::default_max_poll;
+    int ibv_max_poll = spead2::send::udp_ibv_stream_config::default_max_poll;
 #endif
     std::vector<std::string> dest;
 };
@@ -145,6 +145,10 @@ static options parse_args(int argc, const char **argv)
         {
             if (opts.tcp)
                 opts.buffer = spead2::send::tcp_stream::default_buffer_size;
+#if SPEAD2_USE_IBV
+            else if (opts.ibv)
+                opts.buffer = spead2::send::udp_ibv_stream_config::default_buffer_size;
+#endif
             else
                 opts.buffer = spead2::send::udp_stream::default_buffer_size;
         }

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -461,11 +461,12 @@ class TestPassthroughUdpIbv(BaseTestPassthroughSubstreams):
         # The buffer size is deliberately reduced so that we test the
         # wrapping once the buffer has been used up
         if n == 1:
-            return spead2.send.UdpIbvStream(
-                thread_pool, self.MCAST_GROUP, 8876,
-                spead2.send.StreamConfig(rate=1e7),
-                self._interface_address(),
-                buffer_size=64 * 1024)
+            with pytest.deprecated_call():
+                return spead2.send.UdpIbvStream(
+                    thread_pool, self.MCAST_GROUP, 8876,
+                    spead2.send.StreamConfig(rate=1e7),
+                    self._interface_address(),
+                    buffer_size=64 * 1024)
         else:
             return spead2.send.UdpIbvStream(
                 thread_pool,

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -458,18 +458,22 @@ class TestPassthroughUdpIbv(BaseTestPassthroughSubstreams):
             receiver.add_udp_ibv_reader([(self.MCAST_GROUP, 8876 + i)], self._interface_address())
 
     def prepare_senders(self, thread_pool, n):
+        # The buffer size is deliberately reduced so that we test the
+        # wrapping once the buffer has been used up
         if n == 1:
             return spead2.send.UdpIbvStream(
                 thread_pool, self.MCAST_GROUP, 8876,
                 spead2.send.StreamConfig(rate=1e7),
-                self._interface_address())
+                self._interface_address(),
+                buffer_size=64 * 1024)
         else:
             return spead2.send.UdpIbvStream(
                 thread_pool,
                 spead2.send.StreamConfig(rate=1e7),
                 spead2.send.UdpIbvStreamConfig(
                     endpoints=[(self.MCAST_GROUP, 8876 + i) for i in range(n)],
-                    interface_address=self._interface_address()
+                    interface_address=self._interface_address(),
+                    buffer_size=64 * 1024
                 )
             )
 

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -466,9 +466,12 @@ class TestPassthroughUdpIbv(BaseTestPassthroughSubstreams):
         else:
             return spead2.send.UdpIbvStream(
                 thread_pool,
-                [(self.MCAST_GROUP, 8876 + i) for i in range(n)],
                 spead2.send.StreamConfig(rate=1e7),
-                self._interface_address())
+                spead2.send.UdpIbvStreamConfig(
+                    endpoints=[(self.MCAST_GROUP, 8876 + i) for i in range(n)],
+                    interface_address=self._interface_address()
+                )
+            )
 
 
 class TestPassthroughTcp(BaseTestPassthrough):

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -473,7 +473,7 @@ class TestPassthroughUdpIbv(BaseTestPassthroughSubstreams):
                 )
             )
 
-    @pytest.mark.parametrize('num_items', [1, 3, 4, 10])
+    @pytest.mark.parametrize('num_items', [0, 1, 3, 4, 10])
     def test_memory_regions(self, num_items):
         receiver = spead2.recv.Stream(spead2.ThreadPool(), spead2.recv.StreamConfig())
         receiver.add_udp_ibv_reader([(self.MCAST_GROUP, 8876)], self._interface_address())

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -591,10 +591,10 @@ class TestUdpIbvStreamConfig:
         config = spead2.send.UdpIbvStreamConfig()
         assert config.endpoints == []
         assert config.interface_address == ''
-        assert config.buffer_size == spead2.send.UdpIbvStream.DEFAULT_BUFFER_SIZE
+        assert config.buffer_size == spead2.send.UdpIbvStreamConfig.DEFAULT_BUFFER_SIZE
         assert config.ttl == 1
         assert config.comp_vector == 0
-        assert config.max_poll == spead2.send.UdpIbvStream.DEFAULT_MAX_POLL
+        assert config.max_poll == spead2.send.UdpIbvStreamConfig.DEFAULT_MAX_POLL
         assert config.memory_regions == []
 
     def test_kwargs_construct(self):
@@ -619,7 +619,7 @@ class TestUdpIbvStreamConfig:
     def test_default_buffer_size(self):
         config = spead2.send.UdpIbvStreamConfig()
         config.buffer_size = 0
-        assert config.buffer_size == spead2.send.UdpIbvStream.DEFAULT_BUFFER_SIZE
+        assert config.buffer_size == spead2.send.UdpIbvStreamConfig.DEFAULT_BUFFER_SIZE
 
     def test_bad_max_poll(self):
         config = spead2.send.UdpIbvStreamConfig()


### PR DESCRIPTION
The number of constructor arguments was getting out of hand, so I've made a config object (udp_ibv_stream_config). One can now add contiguous ranges of memory to the config object, and they'll get turned into ibv_mr's, and used directly for sending.

I've made a somewhat arbitrary limit of 4 scatter-gather entries per packet, beyond which it'll fall back to the old behaviour. 2 is probably sufficient for all the critical MeerKAT use cases I can think of (headers plus one payload item); 3 will be sufficient for multiple payload items as long as they're each at least packet-sized; so 4 should be plenty.