### PR TITLE
Disable hardware rate limiter by default

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -27,6 +27,9 @@ Other changes:
 - Setting a buffer size of 0 for a :py:class:`~spead2.send.UdpIbvStream` now
   uses the default buffer size, instead of a 1-packet buffer.
 - Fix :program:`spead2_bench.py` ignoring the :opt:`--send-affinity` option.
+- The hardware rate limiting introduced in 3.0.0b1 is now disabled by default,
+  as it proved to be significantly less accurate than the software rate limiter
+  in some cases.
 
 Additionally, refer to the changes for 3.0.0b1 below.
 

--- a/doc/py-send.rst
+++ b/doc/py-send.rst
@@ -25,14 +25,12 @@ configuration between the stream classes, configuration is encapsulated in a
      transmission rate, the rate will be increased until the average rate
      has caught up. This value specifies the "catch-up" rate, as a ratio to the
      target rate.
-   :param bool allow_hw_rate: If true (the default), then hardware-based rate
+   :param bool allow_hw_rate: If true, then hardware-based rate
      limiting may be used if available. In this case it is
      implementation-defined whether `burst_rate_ratio` and `burst_size` have
-     any effect. In most cases the default is fine and will produce results
-     that are at least as good as the software limiter with the default values
-     of these settings (in both rate accuracy and burst control), but this flag
-     allows it to be disabled if it causes problems or if there are specific
-     requirements on bursts.
+     any effect. This will often produce results that are at least as good as
+     the software limiter, but in some cases (particularly higher data rates)
+     the overall rate becomes less accurate and so it is disabled by default.
 
    The constructor arguments are also instance attributes.
 

--- a/include/spead2/send_stream.h
+++ b/include/spead2/send_stream.h
@@ -53,7 +53,7 @@ public:
     static constexpr std::size_t default_max_heaps = 4;
     static constexpr std::size_t default_burst_size = 65536;
     static constexpr double default_burst_rate_ratio = 1.05;
-    static constexpr bool default_allow_hw_rate = true;
+    static constexpr bool default_allow_hw_rate = false;
 
     /// Set maximum packet size to use (only counts the UDP payload, not L1-4 headers).
     stream_config &set_max_packet_size(std::size_t max_packet_size);

--- a/src/spead2/tools/bench_asyncio.py
+++ b/src/spead2/tools/bench_asyncio.py
@@ -304,8 +304,8 @@ def main():
     group.add_argument('--burst-rate-ratio', metavar='RATIO', type=float,
                        default=spead2.send.StreamConfig.DEFAULT_BURST_RATE_RATIO,
                        help='Hard rate limit, relative to nominal rate [%(default)s]')
-    group.add_argument('--no-hw-rate', dest='allow_hw_rate', action='store_false',
-                       help='Do not use hardware rate limiting')
+    group.add_argument('--allow-hw-rate', action='store_true',
+                       help='Use hardware rate limiting if available')
     if hasattr(spead2.send, 'UdpIbvStream'):
         group.add_argument('--send-ibv', type=str, metavar='ADDRESS',
                            help='Use ibverbs with this interface address [no]')

--- a/src/spead2/tools/send_asyncio.py
+++ b/src/spead2/tools/send_asyncio.py
@@ -85,8 +85,8 @@ def get_args():
     group.add_argument('--burst-rate-ratio', metavar='RATIO', type=float,
                        default=spead2.send.StreamConfig.DEFAULT_BURST_RATE_RATIO,
                        help='Hard rate limit, relative to --rate [%(default)s]')
-    group.add_argument('--no-hw-rate', dest='allow_hw_rate', action='store_false',
-                       help='Do not use hardware rate limiting')
+    group.add_argument('--allow-hw-rate', action='store_true',
+                       help='Use hardware rate limiting if available')
     group.add_argument('--max-heaps', metavar='HEAPS', type=int,
                        default=spead2.send.StreamConfig.DEFAULT_MAX_HEAPS,
                        help='Maximum heaps in flight')

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -63,7 +63,7 @@ struct options
     std::size_t recv_buffer = spead2::recv::udp_reader::default_buffer_size;
     std::size_t burst_size = spead2::send::stream_config::default_burst_size;
     double burst_rate_ratio = spead2::send::stream_config::default_burst_rate_ratio;
-    bool no_hw_rate = false;
+    bool allow_hw_rate = false;
     std::size_t heaps = spead2::recv::stream_config::default_max_heaps;
     std::size_t ring_heaps = spead2::recv::ring_stream_config::default_heaps;
     std::size_t mem_max_free = 12;
@@ -146,7 +146,7 @@ static options parse_args(int argc, const char **argv, command_mode mode)
             ("recv-buffer", make_opt(opts.recv_buffer), "Socket buffer size (receiver)")
             ("burst", make_opt(opts.burst_size), "Send burst size")
             ("burst-rate-ratio", make_opt(opts.burst_rate_ratio), "Hard rate limit, relative to the nominal rate")
-            ("no-hw-rate", po::bool_switch(&opts.no_hw_rate)->default_value(opts.no_hw_rate), "Do not use hardware rate limiting")
+            ("allow-hw-rate", po::bool_switch(&opts.allow_hw_rate)->default_value(opts.allow_hw_rate), "Use hardware rate limiting if available")
             ("multicast", make_opt(opts.multicast), "Multicast group to use, instead of unicast")
 #if SPEAD2_USE_IBV
             ("send-ibv", make_opt(opts.send_ibv_if), "Interface address for ibverbs (sender)")
@@ -332,7 +332,7 @@ static std::pair<bool, double> measure_connection_once(
             << opts.recv_buffer << ' '
             << opts.burst_size << ' '
             << opts.burst_rate_ratio << ' '
-            << int(opts.no_hw_rate) << ' '
+            << int(opts.allow_hw_rate) << ' '
             << opts.heaps << ' '
             << opts.ring_heaps << ' '
             << opts.mem_max_free << ' '
@@ -358,7 +358,7 @@ static std::pair<bool, double> measure_connection_once(
         config.set_burst_size(opts.burst_size);
         config.set_max_heaps(opts.heaps);
         config.set_burst_rate_ratio(opts.burst_rate_ratio);
-        config.set_allow_hw_rate(!opts.no_hw_rate);
+        config.set_allow_hw_rate(opts.allow_hw_rate);
 
         /* Build the heaps */
         std::vector<spead2::send::heap> heaps;
@@ -706,7 +706,7 @@ static void main_agent(int argc, const char **argv)
                     >> opts.recv_buffer
                     >> opts.burst_size
                     >> opts.burst_rate_ratio
-                    >> opts.no_hw_rate
+                    >> opts.allow_hw_rate
                     >> opts.heaps
                     >> opts.ring_heaps
                     >> opts.mem_max_free

--- a/src/spead2_send.cpp
+++ b/src/spead2_send.cpp
@@ -55,7 +55,7 @@ struct options
     std::size_t burst = spead2::send::stream_config::default_burst_size;
     double burst_rate_ratio = spead2::send::stream_config::default_burst_rate_ratio;
     std::size_t max_heaps = spead2::send::stream_config::default_max_heaps;
-    bool no_hw_rate = false;
+    bool allow_hw_rate = false;
     double rate = 0.0;
     int ttl = 1;
 #if SPEAD2_USE_IBV
@@ -105,7 +105,7 @@ static options parse_args(int argc, const char **argv)
         ("buffer", make_opt_no_default(opts.buffer), "Socket buffer size")
         ("burst", make_opt(opts.burst), "Burst size")
         ("burst-rate-ratio", make_opt(opts.burst_rate_ratio), "Hard rate limit, relative to --rate")
-        ("no-hw-rate", make_opt(opts.no_hw_rate), "Do not use hardware rate limiting")
+        ("allow-hw-rate", make_opt(opts.allow_hw_rate), "Use hardware rate limiting if available")
         ("max-heaps", make_opt(opts.max_heaps), "Maximum heaps in flight")
         ("rate", make_opt(opts.rate), "Transmission rate bound (Gb/s)")
         ("ttl", make_opt(opts.ttl), "TTL for multicast target")
@@ -364,7 +364,7 @@ int main(int argc, const char **argv)
     config.set_burst_size(opts.burst);
     config.set_max_heaps(opts.max_heaps);
     config.set_burst_rate_ratio(opts.burst_rate_ratio);
-    config.set_allow_hw_rate(!opts.no_hw_rate);
+    config.set_allow_hw_rate(opts.allow_hw_rate);
     std::unique_ptr<spead2::send::stream> stream;
     auto &io_service = thread_pool.get_io_service();
     boost::asio::ip::address interface_address;


### PR DESCRIPTION
I found some cases where it could be pretty inaccurate e.g. asking for
90 Gbps would actually yield 72 Gbps.