### PR TITLE
Overhaul command-line handling in C++ tools

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 global-include Makefile.in
 global-include aclocal.m4
-exclude src/common_features.h
+exclude include/spead2/common_features.h
 exclude python-build.cfg
 exclude .gitignore
 include configure

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -21,14 +21,14 @@ Other changes:
 - Change :cpp:class:`spead2::send::streambuf_stream` so that when the
   streambuf only partially writes a packet, the partial byte count is
   included in the count returned to the callback.
-- :cpp:class:`spead2::send::stream::flush` now only blocks until the
+- :cpp:func:`spead2::send::stream::flush` now only blocks until the
   previously enqueued heaps are completed. Another thread that keeps adding
   heaps would previously have prevented it from returning.
 - Partially rewrite the sending infrastructure, resulting in performance
   improvements, in some cases of over 10%.
 - Setting a buffer size of 0 for a :py:class:`~spead2.send.UdpIbvStream` now
   uses the default buffer size, instead of a 1-packet buffer.
-- Fix :program:`spead2_bench.py` ignoring the :opt:`--send-affinity` option.
+- Fix :program:`spead2_bench.py` ignoring the :option:`!--send-affinity` option.
 - The hardware rate limiting introduced in 3.0.0b1 is now disabled by default,
   as it proved to be significantly less accurate than the software rate limiter
   in some cases.
@@ -131,14 +131,14 @@ Other changes:
 
 - Significant performance improvements to send code (in some cases an order of
   magnitude improvement).
-- Add :option:`--max-heap` option to :program:`spead2_send` and
+- Add :option:`!--max-heap` option to :program:`spead2_send` and
   :program:`spead2_send.py` to control the depth of the send queue.
-- Change the meaning of the :option:`--heaps` option in :program:`spead2_bench`
+- Change the meaning of the :option:`!--heaps` option in :program:`spead2_bench`
   and :program:`spead2_bench.py`: it now also controls the depth of the sending
   queue.
 - Fix a bug in send rate limiting that could allow the target rate to be
   exceeded under some conditions.
-- Remove :option:`--threads` option from C++ :program:`spead2_send`, as the new
+- Remove :option:`!--threads` option from C++ :program:`spead2_send`, as the new
   optimised implementation isn't thread-safe.
 - Disable the ``test_numpy_large`` test on macOS, which was causing frequent
   failures on TravisCI due to dropped packets.
@@ -232,9 +232,9 @@ Other changes:
 
 - Add support for TCP/IP (contributed by Rodrigo Tobar).
 - Changed command-line options for
-  :program:`spead2_send`/:program:`spead2_recv`: :option:`--ibv` and
-  :option:`--netmap` are now boolean flags, and the interface address is set
-  with :option:`--bind`.
+  :program:`spead2_send`/:program:`spead2_recv`: :option:`!--ibv` and
+  :option:`!--netmap` are now boolean flags, and the interface address is set
+  with :option:`!--bind`.
 - Added option to specify interface address for
   :cpp:class:`spead2::send::udp_stream` even when not using the multicast
   constructors.
@@ -258,7 +258,7 @@ Other changes:
 
 - Add progress reports to mcdump
 - Add ability to pass ``-`` as filename to mcdump to skip file writing.
-- Add :option:`--count` option to mcdump
+- Add :option:`!--count` option to mcdump
 
 .. rubric:: Version 1.7.1
 
@@ -276,7 +276,7 @@ that prevented the asyncio integration from being included.
 .. rubric:: Version 1.6.0
 
 - Change :program:`spead2_send.py` and :program:`spead2_send` to interpret
-  the :option:`--rate` option as Gb/s and not Gib/s.
+  the :option:`!--rate` option as Gb/s and not Gib/s.
 - Change send rate limiting to bound the rate at which we catch up if we fall
   behind. This is controlled by a new attribute of
   :class:`~spead2.send.StreamConfig`.
@@ -309,7 +309,7 @@ that prevented the asyncio integration from being included.
 
 .. rubric:: Version 1.4.0
 
-- Remove :option:`--bind` option to :program:`spead2_recv.py` and :program:`spead2_recv`.
+- Remove :option:`!--bind` option to :program:`spead2_recv.py` and :program:`spead2_recv`.
   Instead, use :samp:`{host}:{port}` as the source. This allows subscribing to
   multiple multicast groups.
 - Improved access to information about incomplete heaps
@@ -317,7 +317,7 @@ that prevented the asyncio integration from being included.
 - Add :py:attr:`.MemoryPool.warn_on_empty` control.
 - Add warning when a stream ringbuffer is full.
 - Add statistics to streams.
-- Fix spead2_send.py to send a stop heap when using :option:`--heaps`. It was
+- Fix spead2_send.py to send a stop heap when using :option:`!--heaps`. It was
   acccidentally broken in 1.2.0.
 - Add support for packet timestamping in mcdump.
 - Return the previous logging function from :cpp:func:`spead2::set_log_function`.
@@ -412,7 +412,7 @@ that prevented the asyncio integration from being included.
   operate on any type of stream. This will **break** code that depended on the
   old template class of the same name, which has been renamed to
   :cpp:class:`spead2::send::stream_impl`.
-- Add :option:`--memcpy-nt` to :program:`spead2_recv.py` and
+- Add :option:`!--memcpy-nt` to :program:`spead2_recv.py` and
   :program:`spead2_bench.py`
 - Multicast support in :program:`spead2_bench.py` and :program:`spead2_bench`
 - Changes to the algorithm for :program:`spead2_bench.py` and
@@ -451,7 +451,7 @@ that prevented the asyncio integration from being included.
 
 - Fixed a bug in registering `add_udp_ibv_reader` in Python, which broke
   :program:`spead2_recv.py`, and possibly any other code using this API.
-- Fixed :program:`spead2_recv.py` ignoring :option:`--ibv-max-poll` option
+- Fixed :program:`spead2_recv.py` ignoring :option:`!--ibv-max-poll` option
 
 .. rubric:: Version 0.10.0
 

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -100,7 +100,7 @@ be disabled by passing options to :program:`configure` (run ``./configure -h``
 to see a list of options).
 
 One option that may squeeze out a very small amount of extra performance is
-:option:`--enable-lto` to enable link-time optimization. Up to version 1.2.0
+:option:`!--enable-lto` to enable link-time optimization. Up to version 1.2.0
 this was enabled by default, but it has been disabled because it often needs
 other compiler or OS-specific configuration to make it work. For GCC, typical
 usage is

--- a/doc/migrate-3.rst
+++ b/doc/migrate-3.rst
@@ -111,6 +111,15 @@ argument. As of Python 3.6 (which is now the minimum supported version),
 :py:func:`asyncio.get_event_loop` returns the executing event loop, so there
 is no need to pass the loop explicitly.
 
+Command-line arguments in tools
+-------------------------------
+The command-line handling in :program:`spead2_send`, :program:`spead2_recv` and
+:program:`spead2_bench` has been overhauled and made more consistent. For
+example, :program:`spead_bench` now supports the :option:`!--ttl` option, and
+:option:`!--send-ibv` is now an argument-less flag with the interface address given
+by :option:`!--send-bind` (and similarly for receive). See the help for each
+command for details of the current options.
+
 Removal of deprecated functionality
 -----------------------------------
 The following functions were deprecated in version 2 and have been removed in version 3:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,7 +26,7 @@ mcdump_SOURCES = mcdump.cpp
 mcdump_LDADD = -lboost_program_options $(LDADD)
 endif
 
-spead2_recv_SOURCES = spead2_recv.cpp
+spead2_recv_SOURCES = spead2_recv.cpp spead2_cmdline.cpp
 spead2_recv_LDADD = -lboost_program_options $(LDADD)
 
 spead2_send_SOURCES = spead2_send.cpp spead2_cmdline.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,7 +29,7 @@ endif
 spead2_recv_SOURCES = spead2_recv.cpp
 spead2_recv_LDADD = -lboost_program_options $(LDADD)
 
-spead2_send_SOURCES = spead2_send.cpp
+spead2_send_SOURCES = spead2_send.cpp spead2_cmdline.cpp
 spead2_send_LDADD = -lboost_program_options $(LDADD)
 
 spead2_bench_SOURCES = spead2_bench.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -32,7 +32,7 @@ spead2_recv_LDADD = -lboost_program_options $(LDADD)
 spead2_send_SOURCES = spead2_send.cpp spead2_cmdline.cpp
 spead2_send_LDADD = -lboost_program_options $(LDADD)
 
-spead2_bench_SOURCES = spead2_bench.cpp
+spead2_bench_SOURCES = spead2_bench.cpp spead2_cmdline.cpp
 spead2_bench_LDADD = -lboost_program_options $(LDADD)
 
 spead2_unittest_SOURCES = \

--- a/src/send_udp_ibv.cpp
+++ b/src/send_udp_ibv.cpp
@@ -616,7 +616,7 @@ udp_ibv_stream_config &udp_ibv_stream_config::set_comp_vector(int comp_vector)
 
 udp_ibv_stream_config &udp_ibv_stream_config::set_max_poll(int max_poll)
 {
-    if (max_poll <= 1)
+    if (max_poll < 1)
         throw std::invalid_argument("max_poll must be at least 1");
     this->max_poll = max_poll;
     return *this;

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -129,13 +129,13 @@ static options parse_args(int argc, const char **argv, command_mode mode)
     std::map<std::string, std::string> protocol_map, receiver_map, sender_map;
     // Empty values suppress options that aren't applicable
     // Memory pool sizes are managed automatically
+    protocol_map["tcp"] = "";
     receiver_map["mem-pool"] = "";
     receiver_map["mem-lower"] = "";
     receiver_map["mem-upper"] = "";
     switch (mode)
     {
     case command_mode::MEM:
-        protocol_map["tcp"] = "";
         receiver_map["buffer"] = "";
         receiver_map["ibv"] = "";
         receiver_map["ibv-vector"] = "";
@@ -207,10 +207,6 @@ static options parse_args(int argc, const char **argv, command_mode mode)
              || (mode == command_mode::AGENT && !vm.count("port")))
         {
             throw po::error("too few positional options have been specified on the command line");
-        }
-        if (opts.protocol.tcp && !opts.multicast.empty())
-        {
-            throw po::error("--multicast and --tcp are incompatible");
         }
 #if SPEAD2_USE_IBV
         if (opts.sender.ibv && opts.multicast.empty())

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -217,6 +217,7 @@ static options parse_args(int argc, const char **argv, command_mode mode)
         if (mode != command_mode::AGENT)
         {
             // Initialise memory pool sizes based on heap size
+            opts.receiver.mem_pool = true;
             opts.receiver.mem_lower = opts.heap_size;
             opts.receiver.mem_upper = opts.heap_size + 1024;  // more than enough for overheads
             opts.protocol.notify();

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -156,6 +156,8 @@ static options parse_args(int argc, const char **argv, command_mode mode)
         sender_map["ibv-max-poll"] = "send-max-poll";
         sender_map["rate"] = "";   // Controlled by test
         break;
+    case command_mode::AGENT:
+        break;
     }
 
     if (mode == command_mode::MASTER || mode == command_mode::MEM)

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -129,9 +129,9 @@ static options parse_args(int argc, const char **argv, command_mode mode)
     std::map<std::string, std::string> protocol_map, receiver_map, sender_map;
     // Empty values suppress options that aren't applicable
     // Memory pool sizes are managed automatically
-    receiver_map["mem_pool"] = "";
-    receiver_map["mem_lower"] = "";
-    receiver_map["mem_upper"] = "";
+    receiver_map["mem-pool"] = "";
+    receiver_map["mem-lower"] = "";
+    receiver_map["mem-upper"] = "";
     switch (mode)
     {
     case command_mode::MEM:

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -219,11 +219,8 @@ static options parse_args(int argc, const char **argv, command_mode mode)
             opts.receiver.mem_upper = opts.heap_size + 1024;  // more than enough for overheads
             opts.protocol.notify();
             opts.receiver.notify(opts.protocol);
-            if (mode == command_mode::MASTER)
-            {
-                opts.sender.max_packet_size = *opts.receiver.max_packet_size;
-                opts.sender.notify(opts.protocol);
-            }
+            opts.sender.max_packet_size = *opts.receiver.max_packet_size;
+            opts.sender.notify(opts.protocol);
         }
         return opts;
     }

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -335,7 +335,8 @@ static std::pair<bool, double> measure_connection_once(
 
         /* Construct the stream */
         spead2::send::sender_options sender_options = opts.sender;
-        sender_options.rate = rate;
+        // sender_options expects rate in Gb/s
+        sender_options.rate = rate * 8e-9;
 
         spead2::thread_pool thread_pool;
         spead2::flavour flavour = sender_options.make_flavour(opts.protocol);

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -212,6 +212,12 @@ static options parse_args(int argc, const char **argv, command_mode mode)
         {
             throw po::error("--multicast and --tcp are incompatible");
         }
+#if SPEAD2_USE_IBV
+        if (opts.sender.ibv && opts.multicast.empty())
+        {
+            throw po::error("--send-ibv requires --multicast");
+        }
+#endif
         if (mode != command_mode::AGENT)
         {
             // Initialise memory pool sizes based on heap size

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -206,6 +206,10 @@ static options parse_args(int argc, const char **argv, command_mode mode)
         {
             throw po::error("too few positional options have been specified on the command line");
         }
+        if (opts.protocol.tcp && !opts.multicast.empty())
+        {
+            throw po::error("--multicast and --tcp are incompatible");
+        }
         if (mode != command_mode::AGENT)
         {
             // Initialise memory pool sizes based on heap size

--- a/src/spead2_cmdline.cpp
+++ b/src/spead2_cmdline.cpp
@@ -48,7 +48,7 @@ namespace spead2
 {
 
 template<typename Proto>
-static std::vector<boost::asio::ip::basic_endpoint<Proto>> parse_endpoints(
+std::vector<boost::asio::ip::basic_endpoint<Proto>> parse_endpoints(
     boost::asio::io_service &io_service, const std::vector<std::string> &endpoints, bool passive)
 {
     typedef boost::asio::ip::basic_resolver<Proto> resolver_type;

--- a/src/spead2_cmdline.cpp
+++ b/src/spead2_cmdline.cpp
@@ -80,26 +80,11 @@ std::vector<boost::asio::ip::basic_endpoint<Proto>> parse_endpoints(
 }
 
 template<typename Proto>
-boost::asio::ip::basic_endpoint<Proto> parse_endpoint(
-    boost::asio::io_service &io_service, const std::string &endpoint, bool passive)
-{
-    return parse_endpoints<Proto>(io_service, {endpoint}, passive)[0];
-}
-
-template<typename Proto>
 std::vector<boost::asio::ip::basic_endpoint<Proto>> parse_endpoints(
     const std::vector<std::string> &endpoints, bool passive)
 {
     boost::asio::io_service io_service;
     return parse_endpoints<Proto>(io_service, endpoints, passive);
-}
-
-template<typename Proto>
-boost::asio::ip::basic_endpoint<Proto> parse_endpoint(
-    const std::string &endpoint, bool passive)
-{
-    boost::asio::io_service io_service;
-    return parse_endpoint<Proto>(io_service, endpoint, passive);
 }
 
 // Explicitly instantiate for TCP and UDP
@@ -113,15 +98,6 @@ template std::vector<boost::asio::ip::udp::endpoint> parse_endpoints<boost::asio
 template std::vector<boost::asio::ip::tcp::endpoint> parse_endpoints<boost::asio::ip::tcp>(
     const std::vector<std::string> &endpoints, bool passive);
 
-template boost::asio::ip::udp::endpoint parse_endpoint<boost::asio::ip::udp>(
-    boost::asio::io_service &io_service, const std::string &endpoint, bool passive);
-template boost::asio::ip::tcp::endpoint parse_endpoint<boost::asio::ip::tcp>(
-    boost::asio::io_service &io_service, const std::string &endpoint, bool passive);
-
-template boost::asio::ip::udp::endpoint parse_endpoint<boost::asio::ip::udp>(
-    const std::string &endpoint, bool passive);
-template boost::asio::ip::tcp::endpoint parse_endpoint<boost::asio::ip::tcp>(
-    const std::string &endpoint, bool passive);
 
 void protocol_options::notify()
 {

--- a/src/spead2_cmdline.cpp
+++ b/src/spead2_cmdline.cpp
@@ -1,0 +1,358 @@
+/* Copyright 2020 SKA South Africa
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file Shared command-line processing for tools
+ */
+
+#include <cassert>
+#include <iostream>
+#include <memory>
+#include <functional>
+#include <vector>
+#include <boost/program_options.hpp>
+#include <spead2/common_features.h>
+#include <spead2/send_tcp.h>
+#include <spead2/send_udp.h>
+#if SPEAD2_USE_IBV
+# include <spead2/send_udp_ibv.h>
+#endif
+#include "spead2_cmdline.h"
+
+namespace po = boost::program_options;
+
+namespace spead2
+{
+
+static std::string apply_prefix(const std::string &prefix, const std::string &option)
+{
+    if (!prefix.empty())
+        return prefix + "-" + option;
+    else
+        return option;
+}
+
+
+template<typename T>
+class make_value_semantic
+{
+public:
+    po::typed_value<T> *operator()(const T &def) const
+    {
+        return po::value<T>()->default_value(def);
+    }
+
+    po::typed_value<T> *operator()(const T &def, T *out) const
+    {
+        return po::value<T>(out)->default_value(def);
+    }
+};
+
+template<>
+class make_value_semantic<bool>
+{
+public:
+    po::typed_value<bool> *operator()(bool def) const
+    {
+        assert(!def);
+        return po::bool_switch();
+    }
+
+    po::typed_value<bool> *operator()(bool def, bool *out) const
+    {
+        assert(!def);
+        return po::bool_switch(out);
+    }
+};
+
+template<typename T>
+class option_adder
+{
+private:
+    po::options_description &desc;
+    T &value;
+    std::string prefix;
+
+public:
+    option_adder(po::options_description &desc, T &value, const std::string &prefix)
+        : desc(desc), prefix(prefix), value(value)
+    {
+    }
+
+    template<typename Getter, typename Setter>
+    void add(const std::string &name, const std::string &description,
+             const Getter &getter, const Setter &setter) const
+    {
+        using namespace std::placeholders;
+        auto def = std::bind(getter, value)();
+        desc.add_options()
+            (apply_prefix(prefix, name).c_str(),
+             make_value_semantic<decltype(def)>()(def)->notifier(std::bind(setter, value, _1)),
+             description.c_str());
+    }
+
+    template<typename U>
+    void add(const std::string &name, const std::string &description, U (T::*data))
+    {
+        desc.add_options()
+            (apply_prefix(prefix, name).c_str(),
+             make_value_semantic<U>()(value.*data, &(value.*data)),
+             description.c_str());
+    }
+
+    void add(const std::string &name, const std::string &description, po::value_semantic *value)
+    {
+        desc.add_options()
+            (apply_prefix(prefix, name).c_str(),
+             value,
+             description.c_str());
+    }
+};
+
+po::options_description protocol_config_options(
+    protocol_config &config, const std::string &prefix)
+{
+    po::options_description desc;
+    option_adder<protocol_config> adder(desc, config, prefix);
+    adder.add("tcp", "Use TCP instead of UDP", &protocol_config::tcp);
+    adder.add("pyspead", "Be bug-compatible with PySPEAD", &protocol_config::pyspead);
+    return desc;
+}
+
+
+namespace send
+{
+
+void writer_config::finalize(const protocol_config &protocol)
+{
+#if SPEAD2_USE_IBV
+    if (protocol.tcp && ibv)
+        throw po::error("--tcp and --ibv cannot be used together");
+    if (ibv && interface_address.is_unspecified())
+        throw po::error("--ibv requires --bind");
+#endif
+
+    if (!buffer)
+    {
+        if (protocol.tcp)
+            buffer = tcp_stream::default_buffer_size;
+#if SPEAD2_USE_IBV
+        else if (ibv)
+            buffer = udp_ibv_stream_config::default_buffer_size;
+#endif
+        else
+            buffer = udp_stream::default_buffer_size;
+    }
+
+    int bug_compat = protocol.pyspead
+        ? flavour.get_bug_compat() | BUG_COMPAT_PYSPEAD_0_5_2
+        : flavour.get_bug_compat() & ~BUG_COMPAT_PYSPEAD_0_5_2;
+    flavour = spead2::flavour(
+        flavour.get_version(),
+        flavour.get_item_pointer_bits(),
+        flavour.get_heap_address_bits(),
+        bug_compat);
+
+#if SPEAD2_USE_IBV
+    udp_ibv_config.set_ttl(ttl);
+    udp_ibv_config.set_buffer_size(*buffer);
+    udp_ibv_config.set_interface_address(interface_address);
+#endif
+}
+
+po::options_description flavour_options(
+    spead2::flavour &flavour, const std::string &prefix)
+{
+    po::options_description desc;
+    option_adder<spead2::flavour> adder(desc, flavour, prefix);
+    // --pyspead is handled in protocol_config
+    adder.add(
+        "addr-bits", "Heap address bits",
+        &flavour::get_heap_address_bits,
+        [](spead2::flavour &f, int addr_bits)
+        {
+            // flavour is immutable, so we have to replace the whole object.
+            f = spead2::flavour(
+                f.get_version(),
+                f.get_item_pointer_bits(),
+                addr_bits,
+                f.get_bug_compat());
+        });
+    return desc;
+}
+
+po::options_description stream_config_options(
+    stream_config &config, bool include_rate, const std::string &prefix)
+{
+    po::options_description desc;
+    option_adder<stream_config> adder(desc, config, prefix);
+    adder.add("packet", "Maximum packet size to send",
+              &stream_config::get_max_packet_size,
+              &stream_config::set_max_packet_size);
+    adder.add("burst", "Burst size",
+              &stream_config::get_burst_size,
+              &stream_config::set_burst_size);
+    adder.add("burst-rate-ratio", "Hard rate limit, relative to --rate",
+              &stream_config::get_burst_rate_ratio,
+              &stream_config::set_burst_rate_ratio);
+    adder.add("allow-hw-rate", "Use hardware rate limiting if available",
+              &stream_config::get_allow_hw_rate,
+              &stream_config::set_allow_hw_rate);
+    adder.add("max-heaps", "Maximum heaps in flight",
+              &stream_config::get_max_heaps,
+              &stream_config::set_max_heaps);
+    if (include_rate)
+    {
+        adder.add("rate", "Transmission rate bound (Gb/s)",
+                  &stream_config::get_rate,
+                  &stream_config::set_rate);
+    }
+    return desc;
+}
+
+#if SPEAD2_USE_IBV
+po::options_description udp_ibv_stream_config_options(
+    udp_ibv_stream_config &config, const std::string &prefix)
+{
+    po::options_description desc;
+    option_adder<udp_ibv_stream_config> adder(desc, config, prefix);
+
+    // interface address and TTL are configured elsewhere
+    adder.add("ibv-vector", "Interrupt vector (-1 for polled)",
+              &udp_ibv_stream_config::get_comp_vector,
+              &udp_ibv_stream_config::set_comp_vector);
+    adder.add("ibv-max-poll", "Maximum number of times to poll in a row",
+              &udp_ibv_stream_config::get_max_poll,
+              &udp_ibv_stream_config::set_max_poll);
+    return desc;
+}
+#endif // SPEAD2_USE_IBV
+
+po::options_description writer_config_options(
+    writer_config &config, bool include_rate, const std::string &prefix)
+{
+    po::options_description desc;
+    option_adder<writer_config> adder(desc, config, prefix);
+    desc.add(flavour_options(config.flavour, prefix));
+#if SPEAD2_USE_IBV
+    adder.add("ibv", "Use ibverbs", &writer_config::ibv);
+    desc.add(udp_ibv_stream_config_options(config.udp_ibv_config, prefix));
+#endif
+    // We don't set a default for buffer, because it depends on the writer
+    adder.add("buffer", "Socket buffer size", po::value<std::size_t>());
+    adder.add("ttl", "TTL for multicast target", &writer_config::ttl);
+    adder.add(
+        "bind", "Local address to bind sockets to",
+        [](const writer_config &config)
+        {
+            return config.interface_address.is_unspecified() ? "" : config.interface_address.to_string();
+        },
+        [](writer_config &config, const std::string &address)
+        {
+            if (address.empty())
+                config.interface_address = boost::asio::ip::address();
+            else
+                config.interface_address = boost::asio::ip::address::from_string(address);
+        });
+    desc.add(stream_config_options(config.config, include_rate, prefix));
+    return desc;
+}
+
+template<typename Proto>
+static std::vector<boost::asio::ip::basic_endpoint<Proto>> get_endpoints(
+    boost::asio::io_service &io_service, const std::vector<std::string> &endpoints)
+{
+    typedef boost::asio::ip::basic_resolver<Proto> resolver_type;
+    resolver_type resolver(io_service);
+    std::vector<boost::asio::ip::basic_endpoint<Proto>> ans;
+    ans.reserve(endpoints.size());
+    for (const std::string &dest : endpoints)
+    {
+        auto colon = dest.rfind(':');
+        if (colon == std::string::npos)
+            throw std::runtime_error("Destination '" + dest + "' does not have the format host:port");
+        typename resolver_type::query query(dest.substr(0, colon), dest.substr(colon + 1));
+        ans.push_back(*resolver.resolve(query));
+    }
+    return ans;
+}
+
+std::unique_ptr<stream> make_stream(
+    boost::asio::io_service &io_service,
+    const protocol_config &protocol, const writer_config &writer,
+    const std::vector<std::string> &endpoints,
+    const std::vector<std::pair<const void *, std::size_t>> &memory_regions)
+{
+    std::unique_ptr<stream> stream;
+    if (protocol.tcp)
+    {
+        auto ep = get_endpoints<boost::asio::ip::tcp>(io_service, endpoints);
+        std::promise<void> promise;
+        auto connect_handler = [&promise] (const boost::system::error_code &e) {
+            if (e)
+                promise.set_exception(std::make_exception_ptr(boost::system::system_error(e)));
+            else
+                promise.set_value();
+        };
+        stream.reset(new tcp_stream(
+            io_service, connect_handler, ep,
+            writer.config, *writer.buffer, writer.interface_address));
+        promise.get_future().get();
+    }
+    else
+    {
+        auto ep = get_endpoints<boost::asio::ip::udp>(io_service, endpoints);
+#if SPEAD2_USE_IBV
+        if (writer.ibv)
+        {
+            udp_ibv_stream_config udp_ibv_config = writer.udp_ibv_config;
+            udp_ibv_config
+                .set_endpoints(ep)
+                .set_memory_regions(memory_regions);
+            stream.reset(new udp_ibv_stream(
+                    io_service, writer.config, udp_ibv_config));
+        }
+        else
+#endif // SPEAD2_USE_IBV
+        {
+            if (ep[0].address().is_multicast())
+            {
+                if (ep[0].address().is_v4())
+                    stream.reset(new udp_stream(
+                        io_service, ep, writer.config, *writer.buffer,
+                        writer.ttl, writer.interface_address));
+                else
+                {
+                    if (!writer.interface_address.is_unspecified())
+                        std::cerr << "--bind is not yet supported for IPv6 multicast, ignoring\n";
+                    stream.reset(new udp_stream(
+                        io_service, ep, writer.config, *writer.buffer,
+                        writer.ttl));
+                }
+            }
+            else
+            {
+                stream.reset(new udp_stream(
+                    io_service, ep, writer.config, *writer.buffer, writer.interface_address));
+            }
+        }
+    }
+    return stream;
+}
+
+} // namespace send
+
+} // namespace spead2

--- a/src/spead2_cmdline.cpp
+++ b/src/spead2_cmdline.cpp
@@ -47,113 +47,90 @@ using boost::asio::ip::tcp;
 namespace spead2
 {
 
-template<typename T>
-class make_value_semantic
+template<typename Proto>
+static std::vector<boost::asio::ip::basic_endpoint<Proto>> parse_endpoints(
+    boost::asio::io_service &io_service, const std::vector<std::string> &endpoints, bool passive)
 {
-public:
-    po::typed_value<T> *operator()(T *out) const
+    typedef boost::asio::ip::basic_resolver<Proto> resolver_type;
+    resolver_type resolver(io_service);
+    std::vector<boost::asio::ip::basic_endpoint<Proto>> ans;
+    ans.reserve(endpoints.size());
+    for (const std::string &dest : endpoints)
     {
-        return po::value<T>(out)->default_value(*out);
-    }
-};
-
-template<typename T>
-class make_value_semantic<boost::optional<T>>
-{
-public:
-    po::typed_value<boost::optional<T>> *operator()(boost::optional<T> *out) const
-    {
-        return po::value<boost::optional<T>>(out);
-    }
-};
-
-template<>
-class make_value_semantic<bool>
-{
-public:
-    po::typed_value<bool> *operator()(bool *out) const
-    {
-        assert(!*out);
-        return po::bool_switch(out);
-    }
-};
-
-class option_adder
-{
-private:
-    po::options_description &desc;
-    std::map<std::string, std::string> name_map;
-
-public:
-    option_adder(po::options_description &desc, const std::map<std::string, std::string> &name_map)
-        : desc(desc), name_map(name_map)
-    {
-    }
-
-    void add(const std::string &name, const std::string &description, po::value_semantic *value) const
-    {
-        auto it = name_map.find(name);
-        std::string new_name = it == name_map.end() ? name : it->second;
-        if (!new_name.empty())
+        auto colon = dest.rfind(':');
+        std::string host, port;
+        if (colon == std::string::npos || colon == 0)
         {
-            desc.add_options()
-                (new_name.c_str(), value, description.c_str());
+            if (!passive)
+                throw std::runtime_error("Destination '" + dest + "' does not have the format host:port");
+            else
+                port = (colon == 0) ? dest.substr(1) : dest;
         }
         else
-            delete value;
+        {
+            host = dest.substr(0, colon);
+            port = dest.substr(colon + 1);
+        }
+        typename resolver_type::query query(
+            host, port,
+            passive ? resolver_type::query::passive : typename resolver_type::flags());
+        ans.push_back(*resolver.resolve(query));
     }
+    return ans;
+}
 
-    template<typename U>
-    typename std::enable_if<!std::is_convertible<U *, po::value_semantic *>::value>::type
-    add(const std::string &name, const std::string &description, U *value)
-    {
-        add(name, description, make_value_semantic<U>()(value));
-    }
-};
+template<typename Proto>
+boost::asio::ip::basic_endpoint<Proto> parse_endpoint(
+    boost::asio::io_service &io_service, const std::string &endpoint, bool passive)
+{
+    return parse_endpoints<Proto>(io_service, {endpoint}, passive)[0];
+}
+
+template<typename Proto>
+std::vector<boost::asio::ip::basic_endpoint<Proto>> parse_endpoints(
+    const std::vector<std::string> &endpoints, bool passive)
+{
+    boost::asio::io_service io_service;
+    return parse_endpoints<Proto>(io_service, endpoints, passive);
+}
+
+template<typename Proto>
+boost::asio::ip::basic_endpoint<Proto> parse_endpoint(
+    const std::string &endpoint, bool passive)
+{
+    boost::asio::io_service io_service;
+    return parse_endpoint<Proto>(io_service, endpoint, passive);
+}
+
+// Explicitly instantiate for TCP and UDP
+template std::vector<boost::asio::ip::udp::endpoint> parse_endpoints<boost::asio::ip::udp>(
+    boost::asio::io_service &io_service, const std::vector<std::string> &endpoints, bool passive);
+template std::vector<boost::asio::ip::tcp::endpoint> parse_endpoints<boost::asio::ip::tcp>(
+    boost::asio::io_service &io_service, const std::vector<std::string> &endpoints, bool passive);
+
+template std::vector<boost::asio::ip::udp::endpoint> parse_endpoints<boost::asio::ip::udp>(
+    const std::vector<std::string> &endpoints, bool passive);
+template std::vector<boost::asio::ip::tcp::endpoint> parse_endpoints<boost::asio::ip::tcp>(
+    const std::vector<std::string> &endpoints, bool passive);
+
+template boost::asio::ip::udp::endpoint parse_endpoint<boost::asio::ip::udp>(
+    boost::asio::io_service &io_service, const std::string &endpoint, bool passive);
+template boost::asio::ip::tcp::endpoint parse_endpoint<boost::asio::ip::tcp>(
+    boost::asio::io_service &io_service, const std::string &endpoint, bool passive);
+
+template boost::asio::ip::udp::endpoint parse_endpoint<boost::asio::ip::udp>(
+    const std::string &endpoint, bool passive);
+template boost::asio::ip::tcp::endpoint parse_endpoint<boost::asio::ip::tcp>(
+    const std::string &endpoint, bool passive);
 
 void protocol_options::notify()
 {
     /* No validation required */
 }
 
-po::options_description protocol_options::make_options(
-    const std::map<std::string, std::string> &name_map)
-{
-    po::options_description desc;
-    option_adder adder(desc, name_map);
-    adder.add("tcp", "Use TCP instead of UDP", &tcp);
-    adder.add("pyspead", "Be bug-compatible with PySPEAD", &pyspead);
-    return desc;
-}
-
 
 namespace recv
 {
-
-po::options_description receiver_options::make_options(
-    const std::map<std::string, std::string> &name_map)
-{
-    po::options_description desc;
-    option_adder adder(desc, name_map);
-    adder.add("bind", "Interface address", &interface_address);
-    adder.add("packet", "Maximum packet size to accept", &max_packet_size);
-    adder.add("buffer", "Socket buffer size", &buffer_size);
-    adder.add("concurrent-heaps", "Maximum number of in-flight heaps", &max_heaps);
-    adder.add("ring-heaps", "Ring buffer capacity in heaps", &ring_heaps);
-    adder.add("mem-pool", "Use a memory pool", &mem_pool);
-    adder.add("mem-lower", "Minimum allocation which will use the memory pool", &mem_lower);
-    adder.add("mem-upper", "Maximum allocation which will use the memory pool", &mem_upper);
-    adder.add("mem-max-free", "Maximum free memory buffers", &mem_max_free);
-    adder.add("mem-initial", "Initial free memory buffers", &mem_initial);
-    adder.add("ring", "Use ringbuffer instead of callbacks", &ring);
-    adder.add("memcpy-nt", "Use non-temporal memcpy", &memcpy_nt);
-#if SPEAD2_USE_IBV
-    adder.add("ibv", "Use ibverbs", &ibv);
-    adder.add("ibv-vector", "Interrupt vector (-1 for polled)", &ibv_comp_vector);
-    adder.add("ibv-max-poll", "Maximum number of times to poll in a row", &ibv_max_poll);
-#endif
-    return desc;
-}
 
 void receiver_options::notify(const protocol_options &protocol)
 {
@@ -163,6 +140,30 @@ void receiver_options::notify(const protocol_options &protocol)
     if (protocol.tcp && ibv)
         throw po::error("--ibv and --tcp are incompatible");
 #endif
+
+    if (!buffer_size)
+    {
+        if (protocol.tcp)
+            buffer_size = spead2::recv::tcp_reader::default_buffer_size;
+#if SPEAD2_USE_IBV
+        else if (ibv)
+            buffer_size = spead2::recv::udp_ibv_reader::default_buffer_size;
+#endif
+        else
+            buffer_size = spead2::recv::udp_reader::default_buffer_size;
+    }
+
+    if (!max_packet_size)
+    {
+        if (protocol.tcp)
+            max_packet_size = spead2::recv::tcp_reader::default_max_size;
+#if SPEAD2_USE_IBV
+        else if (ibv)
+            max_packet_size = spead2::recv::udp_ibv_reader::default_max_size;
+#endif
+        else
+            max_packet_size = spead2::recv::udp_reader::default_max_size;
+    }
 }
 
 stream_config receiver_options::make_stream_config(const protocol_options &protocol) const
@@ -211,6 +212,14 @@ void receiver_options::add_readers(
         bool is_pcap = false;
         if (allow_pcap)
         {
+            // Check whether this looks like <host>:<port> or <port>. If not,
+            // guess that it is a pcap file.
+            std::string port;
+            auto colon = endpoint.rfind(':');
+            if (colon != std::string::npos)
+                port = endpoint.substr(colon + 1);
+            else
+                port = endpoint;
             try
             {
                 boost::lexical_cast<std::uint16_t>(port);
@@ -231,40 +240,30 @@ void receiver_options::add_readers(
         }
         else if (protocol.tcp)
         {
-            tcp::resolver resolver(stream.get_io_service());
-            tcp::resolver::query query(host, port, tcp::resolver::query::address_configured);
-            tcp::endpoint endpoint = *resolver.resolve(query);
-            std::size_t buffer_size = this->buffer_size.value_or(spead2::recv::tcp_reader::default_buffer_size);
-            std::size_t max_packet_size = this->max_packet_size.value_or(spead2::recv::tcp_reader::default_max_size);
-            stream.emplace_reader<spead2::recv::tcp_reader>(endpoint, max_packet_size, buffer_size);
+            tcp::endpoint ep = parse_endpoint<tcp>(stream.get_io_service(), endpoint, true);
+            stream.emplace_reader<spead2::recv::tcp_reader>(ep, *max_packet_size, *buffer_size);
         }
         else
         {
-            udp::resolver resolver(stream.get_io_service());
-            udp::resolver::query query(host, port,
-                boost::asio::ip::udp::resolver::query::address_configured
-                | boost::asio::ip::udp::resolver::query::passive);
-            udp::endpoint endpoint = *resolver.resolve(query);
-            std::size_t buffer_size = this->buffer_size.value_or(spead2::recv::udp_reader::default_buffer_size);
-            std::size_t max_packet_size = this->max_packet_size.value_or(spead2::recv::udp_reader::default_max_size);
+            udp::endpoint ep = parse_endpoint<udp>(stream.get_io_service(), endpoint, true);
 #if SPEAD2_USE_IBV
             if (ibv)
             {
-                ibv_endpoints.push_back(endpoint);
+                ibv_endpoints.push_back(ep);
             }
             else
 #endif
-            if (endpoint.address().is_v4() && !interface_address.empty())
+            if (ep.address().is_v4() && !interface_address.empty())
             {
                 stream.emplace_reader<spead2::recv::udp_reader>(
-                    endpoint, max_packet_size, buffer_size,
+                    ep, *max_packet_size, *buffer_size,
                     boost::asio::ip::address_v4::from_string(interface_address));
             }
             else
             {
                 if (!interface_address.empty())
                     std::cerr << "--bind is not implemented for IPv6\n";
-                stream.emplace_reader<spead2::recv::udp_reader>(endpoint, max_packet_size, buffer_size);
+                stream.emplace_reader<spead2::recv::udp_reader>(ep, *max_packet_size, *buffer_size);
             }
         }
     }
@@ -272,10 +271,8 @@ void receiver_options::add_readers(
     if (!ibv_endpoints.empty())
     {
         boost::asio::ip::address interface_address = boost::asio::ip::address::from_string(this->interface_address);
-        std::size_t buffer_size = this->buffer_size.value_or(spead2::recv::udp_ibv_reader::default_buffer_size);
-        std::size_t max_packet_size = this->max_packet_size.value_or(spead2::recv::udp_ibv_reader::default_max_size);
         stream.emplace_reader<spead2::recv::udp_ibv_reader>(
-            ibv_endpoints, interface_address, max_packet_size, buffer_size,
+            ibv_endpoints, interface_address, *max_packet_size, *buffer_size,
             ibv_comp_vector, ibv_max_poll);
     }
 #endif
@@ -295,29 +292,18 @@ void sender_options::notify(const protocol_options &protocol)
     if (ibv && interface_address.empty())
         throw po::error("--ibv requires --bind");
 #endif
-}
 
-po::options_description sender_options::make_options(
-    const std::map<std::string, std::string> &name_map)
-{
-    po::options_description desc;
-    option_adder adder(desc, name_map);
-    adder.add("addr-bits", "Heap address bits", &heap_address_bits);
-    adder.add("packet", "Maximum packet size to send", &max_packet_size);
-    adder.add("bind", "Local address to bind sockets to", &interface_address);
-    adder.add("buffer", "Socket buffer size", &buffer_size);
-    adder.add("burst", "Burst size", &burst_size);
-    adder.add("burst-rate-ratio", "Hard rate limit, relative to --rate", &burst_rate_ratio);
-    adder.add("max-heaps", "Maximum heaps in flight", &max_heaps);
-    adder.add("allow-hw-rate", "Use hardware rate limiting if available", &allow_hw_rate);
-    adder.add("rate", "Transmission rate bound (Gb/s)", &rate);
-    adder.add("ttl", "TTL for multicast target", &ttl);
+    if (!buffer_size)
+    {
+        if (protocol.tcp)
+            buffer_size = tcp_stream::default_buffer_size;
 #if SPEAD2_USE_IBV
-    adder.add("ibv", "Use ibverbs", &ibv);
-    adder.add("ibv-vector", "Interrupt vector (-1 for polled)", &ibv_comp_vector);
-    adder.add("ibv-max-poll", "Maximum number of times to poll in a row", &ibv_max_poll);
+        else if (ibv)
+            buffer_size = udp_ibv_stream_config::default_buffer_size;
 #endif
-    return desc;
+        else
+            buffer_size = udp_stream::default_buffer_size;
+    }
 }
 
 flavour sender_options::make_flavour(const protocol_options &protocol) const
@@ -338,25 +324,6 @@ stream_config sender_options::make_stream_config() const
         .set_allow_hw_rate(allow_hw_rate);
 }
 
-template<typename Proto>
-static std::vector<boost::asio::ip::basic_endpoint<Proto>> get_endpoints(
-    boost::asio::io_service &io_service, const std::vector<std::string> &endpoints)
-{
-    typedef boost::asio::ip::basic_resolver<Proto> resolver_type;
-    resolver_type resolver(io_service);
-    std::vector<boost::asio::ip::basic_endpoint<Proto>> ans;
-    ans.reserve(endpoints.size());
-    for (const std::string &dest : endpoints)
-    {
-        auto colon = dest.rfind(':');
-        if (colon == std::string::npos)
-            throw std::runtime_error("Destination '" + dest + "' does not have the format host:port");
-        typename resolver_type::query query(dest.substr(0, colon), dest.substr(colon + 1));
-        ans.push_back(*resolver.resolve(query));
-    }
-    return ans;
-}
-
 std::unique_ptr<stream> sender_options::make_stream(
     boost::asio::io_service &io_service,
     const protocol_options &protocol,
@@ -370,7 +337,7 @@ std::unique_ptr<stream> sender_options::make_stream(
         interface_address = boost::asio::ip::address::from_string(this->interface_address);
     if (protocol.tcp)
     {
-        auto ep = get_endpoints<boost::asio::ip::tcp>(io_service, endpoints);
+        auto ep = parse_endpoints<boost::asio::ip::tcp>(io_service, endpoints, false);
         std::promise<void> promise;
         auto connect_handler = [&promise] (const boost::system::error_code &e) {
             if (e)
@@ -380,12 +347,12 @@ std::unique_ptr<stream> sender_options::make_stream(
         };
         stream.reset(new tcp_stream(
             io_service, connect_handler, ep, config,
-            buffer_size.value_or(tcp_stream::default_buffer_size), interface_address));
+            *buffer_size, interface_address));
         promise.get_future().get();
     }
     else
     {
-        auto ep = get_endpoints<boost::asio::ip::udp>(io_service, endpoints);
+        auto ep = parse_endpoints<boost::asio::ip::udp>(io_service, endpoints, false);
 #if SPEAD2_USE_IBV
         if (ibv)
         {
@@ -396,33 +363,31 @@ std::unique_ptr<stream> sender_options::make_stream(
                 .set_memory_regions(memory_regions)
                 .set_ttl(ttl)
                 .set_comp_vector(ibv_comp_vector)
-                .set_max_poll(ibv_max_poll);
-            if (buffer_size)
-                udp_ibv_config.set_buffer_size(*buffer_size);
+                .set_max_poll(ibv_max_poll)
+                .set_buffer_size(*buffer_size);
             stream.reset(new udp_ibv_stream(io_service, config, udp_ibv_config));
         }
         else
 #endif // SPEAD2_USE_IBV
         {
-            std::size_t buffer_size = this->buffer_size.value_or(udp_stream::default_buffer_size);
             if (ep[0].address().is_multicast())
             {
                 if (ep[0].address().is_v4())
                     stream.reset(new udp_stream(
-                        io_service, ep, config, buffer_size,
+                        io_service, ep, config, *buffer_size,
                         ttl, interface_address));
                 else
                 {
                     if (!this->interface_address.empty())
                         std::cerr << "--bind is not yet supported for IPv6 multicast, ignoring\n";
                     stream.reset(new udp_stream(
-                        io_service, ep, config, buffer_size, ttl));
+                        io_service, ep, config, *buffer_size, ttl));
                 }
             }
             else
             {
                 stream.reset(new udp_stream(
-                    io_service, ep, config, buffer_size, interface_address));
+                    io_service, ep, config, *buffer_size, interface_address));
             }
         }
     }

--- a/src/spead2_cmdline.cpp
+++ b/src/spead2_cmdline.cpp
@@ -73,7 +73,7 @@ static std::vector<boost::asio::ip::basic_endpoint<Proto>> parse_endpoints(
         }
         typename resolver_type::query query(
             host, port,
-            passive ? resolver_type::query::passive : typename resolver_type::flags());
+            passive ? resolver_type::query::passive : typename resolver_type::query::flags());
         ans.push_back(*resolver.resolve(query));
     }
     return ans;

--- a/src/spead2_cmdline.h
+++ b/src/spead2_cmdline.h
@@ -15,7 +15,7 @@
  */
 
 /**
- * @file Shared command-line processing for tools
+ * @file Shared command-line processing for tools.
  */
 
 #ifndef SPEAD2_CMDLINE_H
@@ -44,56 +44,31 @@
 namespace spead2
 {
 
-namespace detail
+template<typename T>
+static inline boost::program_options::typed_value<T> *
+make_value_semantic(T *out)
 {
+    return boost::program_options::value<T>(out)->default_value(*out);
+}
 
 template<typename T>
-class make_value_semantic_impl
+static inline boost::program_options::typed_value<boost::optional<T>> *
+make_value_semantic(boost::optional<T> *out)
 {
-public:
-    boost::program_options::typed_value<T> *operator()(T *out) const
-    {
-        return boost::program_options::value<T>(out)->default_value(*out);
-    }
-};
+    return boost::program_options::value(out);
+}
 
 template<typename T>
-class make_value_semantic_impl<boost::optional<T>>
+static inline boost::program_options::typed_value<std::vector<T>> *
+make_value_semantic(std::vector<T> *out)
 {
-public:
-    boost::program_options::typed_value<boost::optional<T>> *operator()(boost::optional<T> *out) const
-    {
-        return boost::program_options::value<boost::optional<T>>(out);
-    }
-};
+    return boost::program_options::value(out)->composing();
+}
 
-template<>
-class make_value_semantic_impl<bool>
+static inline boost::program_options::typed_value<bool> *
+make_value_semantic(bool *out)
 {
-public:
-    boost::program_options::typed_value<bool> *operator()(bool *out) const
-    {
-        assert(!*out);
-        return boost::program_options::bool_switch(out);
-    }
-};
-
-template<typename T>
-class make_value_semantic_impl<std::vector<T>>
-{
-public:
-    boost::program_options::typed_value<std::vector<T>> *operator()(std::vector<T> *out) const
-    {
-        return boost::program_options::value<std::vector<T>>(out)->composing();
-    }
-};
-
-} // namespace detail
-
-template<typename T>
-boost::program_options::typed_value<T> *make_value_semantic(T *out)
-{
-    return detail::make_value_semantic_impl<T>()(out);
+    return boost::program_options::bool_switch(out);
 }
 
 class option_adder

--- a/src/spead2_cmdline.h
+++ b/src/spead2_cmdline.h
@@ -1,0 +1,84 @@
+/* Copyright 2020 SKA South Africa
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file Shared command-line processing for tools
+ */
+
+#ifndef SPEAD2_CMDLINE_H
+#define SPEAD2_CMDLINE_H
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <utility>
+#include <boost/asio.hpp>
+#include <boost/program_options.hpp>
+#include <boost/optional.hpp>
+#include <spead2/common_features.h>
+#include <spead2/common_flavour.h>
+#include <spead2/send_stream.h>
+#if SPEAD2_USE_IBV
+# include <spead2/send_udp_ibv.h>
+#endif
+
+namespace spead2
+{
+
+struct protocol_config
+{
+    bool tcp = false;
+    bool pyspead = false;
+};
+
+boost::program_options::options_description protocol_config_options(
+    protocol_config &config, const std::string &prefix = "");
+
+namespace send
+{
+
+struct writer_config
+{
+    spead2::flavour flavour;
+    stream_config config;
+#if SPEAD2_USE_IBV
+    bool ibv = false;
+    udp_ibv_stream_config udp_ibv_config;
+#endif
+    int ttl = 1;
+    boost::optional<std::size_t> buffer;
+    boost::asio::ip::address interface_address;
+
+    void finalize(const protocol_config &protocol);
+};
+
+boost::program_options::options_description flavour_options(
+    spead2::flavour &flavour, const std::string &prefix = "");
+
+boost::program_options::options_description writer_config_options(
+    writer_config &config, bool include_rate = true, const std::string &prefix = "");
+
+std::unique_ptr<stream> make_stream(
+    boost::asio::io_service &io_service,
+    const protocol_config &protocol, const writer_config &writer,
+    const std::vector<std::string> &endpoints,
+    const std::vector<std::pair<const void *, std::size_t>> &memory_regions);
+
+} // namespace send
+
+} // namespace spead2
+
+#endif // SPEAD2_CMDLINE_H

--- a/src/spead2_cmdline.h
+++ b/src/spead2_cmdline.h
@@ -151,8 +151,11 @@ std::vector<boost::asio::ip::basic_endpoint<Proto>> parse_endpoints(
 
 /// Like @ref parse_endpoints, but for a single endpoint.
 template<typename Proto>
-boost::asio::ip::basic_endpoint<Proto> parse_endpoint(
-    boost::asio::io_service &io_service, const std::string &endpoint, bool passive);
+static inline boost::asio::ip::basic_endpoint<Proto> parse_endpoint(
+    boost::asio::io_service &io_service, const std::string &endpoint, bool passive)
+{
+    return parse_endpoints<Proto>(io_service, {endpoint}, passive)[0];
+}
 
 // Variants which provide their own io_service
 template<typename Proto>
@@ -160,9 +163,11 @@ std::vector<boost::asio::ip::basic_endpoint<Proto>> parse_endpoints(
     const std::vector<std::string> &endpoints, bool passive);
 
 template<typename Proto>
-boost::asio::ip::basic_endpoint<Proto> parse_endpoint(
-    const std::string &endpoint, bool passive);
-
+static inline boost::asio::ip::basic_endpoint<Proto> parse_endpoint(
+    const std::string &endpoint, bool passive)
+{
+    return parse_endpoints<Proto>({endpoint}, passive)[0];
+}
 
 namespace recv
 {

--- a/src/spead2_cmdline.h
+++ b/src/spead2_cmdline.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include <map>
 #include <utility>
+#include <cassert>
 #include <istream>
 #include <ostream>
 #include <boost/asio.hpp>
@@ -68,6 +69,7 @@ make_value_semantic(std::vector<T> *out)
 static inline boost::program_options::typed_value<bool> *
 make_value_semantic(bool *out)
 {
+    assert(!*out);    // Cannot make it a bool switch if the default is true.
     return boost::program_options::bool_switch(out);
 }
 

--- a/src/spead2_recv.cpp
+++ b/src/spead2_recv.cpp
@@ -98,7 +98,7 @@ static options parse_args(int argc, const char **argv)
             usage(std::cout, desc);
             std::exit(0);
         }
-        if (!opts.sources.empty())
+        if (opts.sources.empty())
             throw po::error("At least one source is required");
         opts.protocol.notify();
         opts.receiver.notify(opts.protocol);

--- a/src/spead2_recv.cpp
+++ b/src/spead2_recv.cpp
@@ -79,6 +79,8 @@ static options parse_args(int argc, const char **argv)
 
     hidden.add_options()
         ("source", spead2::make_value_semantic(&opts.sources), "sources");
+    desc.add_options()
+        ("help,h", "Show help text");
     all.add(desc);
     all.add(hidden);
 

--- a/src/spead2_recv.cpp
+++ b/src/spead2_recv.cpp
@@ -118,7 +118,7 @@ static options parse_args(int argc, const char **argv)
             throw po::error("At least one source is required");
         opts.sources = vm["source"].as<std::vector<std::string>>();
         opts.protocol.notify();
-        opts.receiver.notify();
+        opts.receiver.notify(opts.protocol);
         return opts;
     }
     catch (po::error &e)
@@ -266,7 +266,7 @@ int main(int argc, const char **argv)
     }
     else
     {
-        if (opts.sources.size() > 1 && opts.ring)
+        if (opts.sources.size() > 1 && opts.receiver.ring)
         {
             std::cerr << "Multiple streams cannot be used with --ring\n";
             std::exit(2);

--- a/src/spead2_send.cpp
+++ b/src/spead2_send.cpp
@@ -35,6 +35,7 @@
 #if SPEAD2_USE_IBV
 # include <spead2/send_udp_ibv.h>
 #endif
+#include "spead2_cmdline.h"
 
 namespace po = boost::program_options;
 namespace asio = boost::asio;
@@ -43,26 +44,11 @@ using boost::asio::ip::tcp;
 
 struct options
 {
+    spead2::protocol_config protocol;
+    spead2::send::writer_config writer;
     std::size_t heap_size = 4194304;
     std::size_t items = 1;
     std::int64_t heaps = -1;
-    bool pyspead = false;
-    bool tcp = false;
-    std::string bind;
-    int addr_bits = 40;
-    std::size_t packet = spead2::send::stream_config::default_max_packet_size;
-    std::size_t buffer;
-    std::size_t burst = spead2::send::stream_config::default_burst_size;
-    double burst_rate_ratio = spead2::send::stream_config::default_burst_rate_ratio;
-    std::size_t max_heaps = spead2::send::stream_config::default_max_heaps;
-    bool allow_hw_rate = false;
-    double rate = 0.0;
-    int ttl = 1;
-#if SPEAD2_USE_IBV
-    bool ibv = false;
-    int ibv_comp_vector = 0;
-    int ibv_max_poll = spead2::send::udp_ibv_stream_config::default_max_poll;
-#endif
     std::vector<std::string> dest;
 };
 
@@ -97,24 +83,9 @@ static options parse_args(int argc, const char **argv)
         ("heap-size", make_opt(opts.heap_size), "Payload size for heap")
         ("items", make_opt(opts.items), "Number of items per heap")
         ("heaps", make_opt(opts.heaps), "Number of data heaps to send (-1=infinite)")
-        ("pyspead", make_opt(opts.pyspead), "Be bug-compatible with PySPEAD")
-        ("addr-bits", make_opt(opts.addr_bits), "Heap address bits")
-        ("tcp", make_opt(opts.tcp), "Use TCP instead than UDP")
-        ("bind", make_opt(opts.bind), "Local address to bind sockets to")
-        ("packet", make_opt(opts.packet), "Maximum packet size to send")
-        ("buffer", make_opt_no_default(opts.buffer), "Socket buffer size")
-        ("burst", make_opt(opts.burst), "Burst size")
-        ("burst-rate-ratio", make_opt(opts.burst_rate_ratio), "Hard rate limit, relative to --rate")
-        ("allow-hw-rate", make_opt(opts.allow_hw_rate), "Use hardware rate limiting if available")
-        ("max-heaps", make_opt(opts.max_heaps), "Maximum heaps in flight")
-        ("rate", make_opt(opts.rate), "Transmission rate bound (Gb/s)")
-        ("ttl", make_opt(opts.ttl), "TTL for multicast target")
-#if SPEAD2_USE_IBV
-        ("ibv", make_opt(opts.ibv), "Use ibverbs")
-        ("ibv-vector", make_opt(opts.ibv_comp_vector), "Interrupt vector (-1 for polled)")
-        ("ibv-max-poll", make_opt(opts.ibv_max_poll), "Maximum number of times to poll in a row")
-#endif
     ;
+    desc.add(spead2::protocol_config_options(opts.protocol));
+    desc.add(spead2::send::writer_config_options(opts.writer));
     hidden.add_options()
         ("destination", make_opt_no_default(opts.dest)->composing(), "Destination host:port")
     ;
@@ -139,23 +110,9 @@ static options parse_args(int argc, const char **argv)
         }
         if (!vm.count("destination"))
             throw po::error("at least one destination is required");
-        if (opts.dest.size() > 1 && opts.tcp)
+        if (opts.dest.size() > 1 && opts.protocol.tcp)
             throw po::error("only one destination is supported with TCP");
-        if (!vm.count("buffer"))
-        {
-            if (opts.tcp)
-                opts.buffer = spead2::send::tcp_stream::default_buffer_size;
-#if SPEAD2_USE_IBV
-            else if (opts.ibv)
-                opts.buffer = spead2::send::udp_ibv_stream_config::default_buffer_size;
-#endif
-            else
-                opts.buffer = spead2::send::udp_stream::default_buffer_size;
-        }
-#if SPEAD2_USE_IBV
-        if (opts.ibv && opts.bind.empty())
-            throw po::error("--ibv requires --bind");
-#endif
+        opts.writer.finalize(opts.protocol);
         return opts;
     }
     catch (po::error &e)
@@ -203,15 +160,13 @@ public:
 };
 
 sender::sender(const options &opts)
-    : max_heaps((opts.heaps < 0 || std::uint64_t(opts.heaps) + opts.dest.size() > opts.max_heaps)
-                ? opts.max_heaps : opts.heaps + opts.dest.size()),
+    : max_heaps((opts.heaps < 0 || std::uint64_t(opts.heaps) + opts.dest.size() > opts.writer.config.get_max_heaps())
+                ? opts.writer.config.get_max_heaps() : opts.heaps + opts.dest.size()),
     n_substreams(opts.dest.size()),
     n_heaps(opts.heaps),
-    flavour(spead2::maximum_version, 64, opts.addr_bits,
-            opts.pyspead ? spead2::BUG_COMPAT_PYSPEAD_0_5_2 : 0),
     value_size(opts.heap_size / (opts.items * sizeof(item_t)) * sizeof(item_t)),
-    first_heap(flavour),
-    last_heap(flavour)
+    first_heap(opts.writer.flavour),
+    last_heap(opts.writer.flavour)
 {
     heaps.reserve(max_heaps);
     for (std::size_t i = 0; i < max_heaps; i++)
@@ -358,73 +313,8 @@ int main(int argc, const char **argv)
     sender s(opts);
 
     spead2::thread_pool thread_pool(1);
-    spead2::send::stream_config config;
-    config.set_max_packet_size(opts.packet);
-    config.set_rate(opts.rate * 1000 * 1000 * 1000 / 8);
-    config.set_burst_size(opts.burst);
-    config.set_max_heaps(opts.max_heaps);
-    config.set_burst_rate_ratio(opts.burst_rate_ratio);
-    config.set_allow_hw_rate(opts.allow_hw_rate);
-    std::unique_ptr<spead2::send::stream> stream;
-    auto &io_service = thread_pool.get_io_service();
-    boost::asio::ip::address interface_address;
-    if (!opts.bind.empty())
-        interface_address = boost::asio::ip::address::from_string(opts.bind);
-
-    if (opts.tcp) {
-        std::vector<tcp::endpoint> endpoints = get_endpoints<tcp>(io_service, opts);
-        auto promise = std::promise<void>();
-        auto connect_handler = [&promise] (const boost::system::error_code &e) {
-            if (e)
-                promise.set_exception(std::make_exception_ptr(boost::system::system_error(e)));
-            else
-                promise.set_value();
-        };
-        stream.reset(new spead2::send::tcp_stream(
-                    io_service, connect_handler, endpoints, config, opts.buffer, interface_address));
-        promise.get_future().get();
-    }
-    else
-    {
-        std::vector<udp::endpoint> endpoints = get_endpoints<udp>(io_service, opts);
-#if SPEAD2_USE_IBV
-        if (opts.ibv)
-        {
-            stream.reset(new spead2::send::udp_ibv_stream(
-                    io_service, config,
-                    spead2::send::udp_ibv_stream_config()
-                        .set_endpoints(endpoints)
-                        .set_interface_address(interface_address)
-                        .set_buffer_size(opts.buffer)
-                        .set_ttl(opts.ttl)
-                        .set_comp_vector(opts.ibv_comp_vector)
-                        .set_max_poll(opts.ibv_max_poll)
-                        .set_memory_regions(s.memory_regions())));
-        }
-        else
-#endif
-        {
-            if (endpoints[0].address().is_multicast())
-            {
-                if (endpoints[0].address().is_v4())
-                    stream.reset(new spead2::send::udp_stream(
-                            io_service, endpoints, config, opts.buffer,
-                            opts.ttl, interface_address));
-                else
-                {
-                    if (!opts.bind.empty())
-                        std::cerr << "--bind is not yet supported for IPv6 multicast, ignoring\n";
-                    stream.reset(new spead2::send::udp_stream(
-                            io_service, endpoints, config, opts.buffer,
-                            opts.ttl));
-                }
-            }
-            else
-            {
-                stream.reset(new spead2::send::udp_stream(
-                        io_service, endpoints, config, opts.buffer, interface_address));
-            }
-        }
-    }
+    std::unique_ptr<spead2::send::stream> stream =
+        spead2::send::make_stream(thread_pool.get_io_service(), opts.protocol, opts.writer,
+                                  opts.dest, s.memory_regions());
     return run(*stream, s);
 }

--- a/src/spead2_send.cpp
+++ b/src/spead2_send.cpp
@@ -58,36 +58,20 @@ static void usage(std::ostream &o, const po::options_description &desc)
     o << desc;
 }
 
-template<typename T>
-static po::typed_value<T> *make_opt(T &var)
-{
-    return po::value<T>(&var)->default_value(var);
-}
-
-static po::typed_value<bool> *make_opt(bool &var)
-{
-    return po::bool_switch(&var)->default_value(var);
-}
-
-template<typename T>
-static po::typed_value<T> *make_opt_no_default(T &var)
-{
-    return po::value<T>(&var);
-}
-
 static options parse_args(int argc, const char **argv)
 {
     options opts;
     po::options_description desc, hidden, all;
     desc.add_options()
-        ("heap-size", make_opt(opts.heap_size), "Payload size for heap")
-        ("items", make_opt(opts.items), "Number of items per heap")
-        ("heaps", make_opt(opts.heaps), "Number of data heaps to send (-1=infinite)")
+        ("heap-size", spead2::make_value_semantic(&opts.heap_size), "Payload size for heap")
+        ("items", spead2::make_value_semantic(&opts.items), "Number of items per heap")
+        ("heaps", spead2::make_value_semantic(&opts.heaps), "Number of data heaps to send (-1=infinite)")
     ;
-    desc.add(opts.protocol.make_options());
-    desc.add(opts.sender.make_options());
+    spead2::option_adder adder(desc);
+    opts.protocol.enumerate(adder);
+    opts.sender.enumerate(adder);
     hidden.add_options()
-        ("destination", make_opt_no_default(opts.dest)->composing(), "Destination host:port")
+        ("destination", spead2::make_value_semantic(&opts.dest), "Destination host:port")
     ;
     all.add(desc);
     all.add(hidden);

--- a/src/spead2_send.cpp
+++ b/src/spead2_send.cpp
@@ -73,6 +73,8 @@ static options parse_args(int argc, const char **argv)
     hidden.add_options()
         ("destination", spead2::make_value_semantic(&opts.dest), "Destination host:port")
     ;
+    desc.add_options()
+        ("help,h", "Show help text");
     all.add(desc);
     all.add(hidden);
 


### PR DESCRIPTION
Each of the C++ tools (spead2_recv, spead2_send, spead2_bench) had its own command-line handling, which lead to a lot of duplication (spead2_recv and spead2_bench had options controlling receivers, spead2_send and spead2_bench had options controlling senders), and there were inconsistencies (e.g. spead2_bench was missing the --ttl option).

There is now a helper file (plus header) where command-line options are registered and which has the logic to build streams from them. Somehow this has lead to an increase in the total lines of code, but it's also brought along some capabilities that were missing, and it'll require less work to add new options in future.

This just covers the C++ tools. The Python equivalents have the same issue, but I'll leave that for a later PR. There are also some misc unrelated fixups that I threw in as I went.