### PR TITLE
Rename udp_ibv_stream_config -> udp_ibv_config 

### DIFF
--- a/doc/cpp-ibverbs.rst
+++ b/doc/cpp-ibverbs.rst
@@ -8,7 +8,7 @@ the :cpp:class:`spead2::recv::udp_ibv_reader` and
 .. doxygenclass:: spead2::recv::udp_ibv_reader
    :members: udp_ibv_reader
 
-.. doxygenclass:: spead2::send::udp_ibv_stream_config
+.. doxygenclass:: spead2::send::udp_ibv_config
    :members:
 
 .. doxygenclass:: spead2::send::udp_ibv_stream

--- a/doc/migrate-3.rst
+++ b/doc/migrate-3.rst
@@ -73,12 +73,12 @@ a "fluent" style e.g.:
    spead2::send::stream_config().set_max_packet_size(9172).set_rate(1e6)
 
 For :doc:`ibverbs <py-ibverbs>` streams the changes are more significant. There
-is now a :py:class:`spead2.send.UdpIbvStreamConfig` class that works similarly
+is now a :py:class:`spead2.send.UdpIbvConfig` class that works similarly
 to :py:class:`spead2.send.StreamConfig`, but configures properties specific to
 the ibverbs stream. The old constructor is still available (but deprecated);
 however, the constants :py:data:`.UdpIbvStream.DEFAULT_BUFFER_SIZE` and
 :py:data:`.UdpIbvStream.DEFAULT_MAX_POLL` have moved to the
-:class:`~spead2.send.UdpIbvStreamConfig` class.
+:class:`~spead2.send.UdpIbvConfig` class.
 
 Substreams
 ----------

--- a/doc/py-ibverbs.rst
+++ b/doc/py-ibverbs.rst
@@ -130,7 +130,7 @@ class, analogous to :py:class:`spead2.send.asyncio.UdpStream`.
 There is an additional configuration class for ibverbs-specific
 configuration:
 
-.. py:class:: spead2.send.UdpIbvStreamConfig(*, endpoints=[], interface_address='', buffer_size=DEFAULT_BUFFER_SIZE, ttl=1, comp_vector=0, max_poll=DEFAULT_MAX_POLL, memory_regions=[])
+.. py:class:: spead2.send.UdpIbvConfig(*, endpoints=[], interface_address='', buffer_size=DEFAULT_BUFFER_SIZE, ttl=1, comp_vector=0, max_poll=DEFAULT_MAX_POLL, memory_regions=[])
 
    :param List[Tuple[str, int]] endpoints: Peer endpoints (one per substream)
    :param str interface_address: Hostname/IP address of the interface which
@@ -173,4 +173,4 @@ configuration:
    :param config: Stream configuration
    :type config: :py:class:`spead2.send.StreamConfig`
    :param udp_ibv_config: Additional stream configuration
-   :type udp_ibv_config: :py:class:`spead2.send.UdpIbvStreamConfig`
+   :type udp_ibv_config: :py:class:`spead2.send.UdpIbvConfig`

--- a/include/spead2/send_udp_ibv.h
+++ b/include/spead2/send_udp_ibv.h
@@ -180,16 +180,16 @@ public:
      *
      * @param io_service   I/O service for sending data
      * @param config       Common stream configuration
-     * @param udp_ibv_config  Class-specific stream configuration
+     * @param ibv_config   Class-specific stream configuration
      *
-     * @throws std::invalid_argument if @a udp_ibv_config does not an interface address set.
-     * @throws std::invalid_argument if @a udp_ibv_config does not have any endpoints set.
+     * @throws std::invalid_argument if @a ibv_config does not have an interface address set.
+     * @throws std::invalid_argument if @a ibv_config does not have any endpoints set.
      * @throws std::invalid_argument if memory regions overlap.
      */
     udp_ibv_stream(
         io_service_ref io_service,
         const stream_config &config,
-        const udp_ibv_stream_config &udp_ibv_config);
+        const udp_ibv_stream_config &ibv_config);
 };
 
 } // namespace send

--- a/include/spead2/send_udp_ibv.h
+++ b/include/spead2/send_udp_ibv.h
@@ -42,7 +42,7 @@ namespace send
 /**
  * Configuration for @ref udp_ibv_stream.
  */
-class udp_ibv_stream_config
+class udp_ibv_config
 {
 public:
     typedef std::pair<const void *, std::size_t> memory_region;
@@ -68,7 +68,7 @@ public:
      * It cannot be used as is, because the interface address and at least one
      * endpoint must be supplied.
      */
-    udp_ibv_stream_config();
+    udp_ibv_config();
 
     /// Get the configured endpoints
     const std::vector<boost::asio::ip::udp::endpoint> &get_endpoints() const { return endpoints; }
@@ -77,13 +77,13 @@ public:
      *
      * @throws std::invalid_argument if any element of @a endpoints is not an IPv4 multicast address.
      */
-    udp_ibv_stream_config &set_endpoints(const std::vector<boost::asio::ip::udp::endpoint> &endpoints);
+    udp_ibv_config &set_endpoints(const std::vector<boost::asio::ip::udp::endpoint> &endpoints);
     /**
      * Append a single endpoint.
      *
      * @throws std::invalid_argument if @a endpoint is not an IPv4 multicast address.
      */
-    udp_ibv_stream_config &add_endpoint(const boost::asio::ip::udp::endpoint &endpoint);
+    udp_ibv_config &add_endpoint(const boost::asio::ip::udp::endpoint &endpoint);
 
     /// Get the currently set interface address
     const boost::asio::ip::address get_interface_address() const { return interface_address; }
@@ -92,7 +92,7 @@ public:
      *
      * @throws std::invalid_argument if @a interface_address is not an IPv4 address.
      */
-    udp_ibv_stream_config &set_interface_address(const boost::asio::ip::address &interface_address);
+    udp_ibv_config &set_interface_address(const boost::asio::ip::address &interface_address);
 
     /// Get the currently configured buffer size.
     std::size_t get_buffer_size() const { return buffer_size; }
@@ -103,12 +103,12 @@ public:
      * used may be slightly different to round it to a whole number of
      * packet-sized slots.
      */
-    udp_ibv_stream_config &set_buffer_size(std::size_t buffer_size);
+    udp_ibv_config &set_buffer_size(std::size_t buffer_size);
 
     /// Get the IP TTL
     std::uint8_t get_ttl() const { return ttl; }
     /// Set the IP TTL
-    udp_ibv_stream_config &set_ttl(std::uint8_t ttl);
+    udp_ibv_config &set_ttl(std::uint8_t ttl);
 
     /// Get the completion channel vector (see @ref set_comp_vector)
     int get_comp_vector() const { return comp_vector; }
@@ -121,7 +121,7 @@ public:
      * vectors and have them load-balanced, without concern for the number
      * available.
      */
-    udp_ibv_stream_config &set_comp_vector(int comp_vector);
+    udp_ibv_config &set_comp_vector(int comp_vector);
 
     /// Get maximum number of times to poll in a row (see @ref set_max_poll)
     int get_max_poll() const { return max_poll; }
@@ -135,7 +135,7 @@ public:
      *
      * @throws std::invalid_argument if @a max_poll is zero.
      */
-    udp_ibv_stream_config &set_max_poll(int max_poll);
+    udp_ibv_config &set_max_poll(int max_poll);
 
     /// Get currently registered memory regions
     const std::vector<memory_region> &get_memory_regions() const { return memory_regions; }
@@ -148,9 +148,9 @@ public:
      * Memory regions must not overlap; this is only validating when constructing
      * the stream.
      */
-    udp_ibv_stream_config &set_memory_regions(const std::vector<memory_region> &memory_regions);
+    udp_ibv_config &set_memory_regions(const std::vector<memory_region> &memory_regions);
     /// Append a memory region (see @ref set_memory_regions)
-    udp_ibv_stream_config &add_memory_region(const void *ptr, std::size_t size);
+    udp_ibv_config &add_memory_region(const void *ptr, std::size_t size);
 };
 
 class udp_ibv_stream : public stream
@@ -159,21 +159,21 @@ public:
     /**
      * Backwards-compatibility constructor (taking only a single endpoint).
      *
-     * Refer to @ref udp_ibv_stream_config for an explanation of the arguments.
+     * Refer to @ref udp_ibv_config for an explanation of the arguments.
      *
      * @throws std::invalid_argument if @a endpoint is not an IPv4 multicast address
      * @throws std::invalid_argument if @a interface_address is not an IPv4 address
      */
-    SPEAD2_DEPRECATED("use udp_ibv_stream_config")
+    SPEAD2_DEPRECATED("use udp_ibv_config")
     udp_ibv_stream(
         io_service_ref io_service,
         const boost::asio::ip::udp::endpoint &endpoint,
         const stream_config &config,
         const boost::asio::ip::address &interface_address,
-        std::size_t buffer_size = udp_ibv_stream_config::default_buffer_size,
+        std::size_t buffer_size = udp_ibv_config::default_buffer_size,
         int ttl = 1,
         int comp_vector = 0,
-        int max_poll = udp_ibv_stream_config::default_max_poll);
+        int max_poll = udp_ibv_config::default_max_poll);
 
     /**
      * Constructor.
@@ -189,7 +189,7 @@ public:
     udp_ibv_stream(
         io_service_ref io_service,
         const stream_config &config,
-        const udp_ibv_stream_config &ibv_config);
+        const udp_ibv_config &ibv_config);
 };
 
 } // namespace send

--- a/src/py_send.cpp
+++ b/src/py_send.cpp
@@ -407,7 +407,7 @@ public:
  * hand. We store a separate copy in the wrapper in a Python-centric format.
  * When constructing the stream, we make a copy with the C++ view.
  */
-class udp_ibv_stream_config_wrapper : public udp_ibv_stream_config
+class udp_ibv_config_wrapper : public udp_ibv_config
 {
 public:
     std::vector<std::pair<std::string, std::uint16_t>> py_endpoints;
@@ -439,13 +439,13 @@ public:
                make_address(pool->get_io_service(), interface_address),
                buffer_size, ttl, comp_vector, max_poll)
     {
-        deprecation_warning("pass a UdpIbvStreamConfig");
+        deprecation_warning("pass a UdpIbvConfig");
     }
 
     udp_ibv_stream_wrapper(
         std::shared_ptr<thread_pool> pool,
         const stream_config &config,
-        const udp_ibv_stream_config &ibv_config,
+        const udp_ibv_config &ibv_config,
         std::vector<py::buffer_info> &&buffer_infos)
         : Base(pool,
                config,
@@ -542,15 +542,15 @@ static py::class_<T> udp_ibv_stream_register(py::module &m, const char *name)
              "thread_pool"_a, "multicast_group"_a, "port"_a,
              "config"_a = stream_config(),
              "interface_address"_a,
-             "buffer_size"_a = udp_ibv_stream_config::default_buffer_size,
+             "buffer_size"_a = udp_ibv_config::default_buffer_size,
              "ttl"_a = 1,
              "comp_vector"_a = 0,
-             "max_poll"_a = udp_ibv_stream_config::default_max_poll)
+             "max_poll"_a = udp_ibv_config::default_max_poll)
         .def(py::init([](std::shared_ptr<thread_pool_wrapper> thread_pool,
                          const stream_config &config,
-                         const udp_ibv_stream_config_wrapper &ibv_config_wrapper)
+                         const udp_ibv_config_wrapper &ibv_config_wrapper)
             {
-                udp_ibv_stream_config ibv_config = ibv_config_wrapper;
+                udp_ibv_config ibv_config = ibv_config_wrapper;
                 ibv_config.set_endpoints(
                     make_endpoints<boost::asio::ip::udp>(
                         thread_pool->get_io_service(),
@@ -873,25 +873,25 @@ py::module register_module(py::module &parent)
     }
 
 #if SPEAD2_USE_IBV
-    py::class_<udp_ibv_stream_config_wrapper>(m, "UdpIbvStreamConfig")
-        .def(py::init(&data_class_constructor<udp_ibv_stream_config_wrapper>))
-        .def_readwrite("endpoints", &udp_ibv_stream_config_wrapper::py_endpoints)
-        .def_readwrite("memory_regions", &udp_ibv_stream_config_wrapper::py_memory_regions)
-        .def_readwrite("interface_address", &udp_ibv_stream_config_wrapper::py_interface_address)
+    py::class_<udp_ibv_config_wrapper>(m, "UdpIbvConfig")
+        .def(py::init(&data_class_constructor<udp_ibv_config_wrapper>))
+        .def_readwrite("endpoints", &udp_ibv_config_wrapper::py_endpoints)
+        .def_readwrite("memory_regions", &udp_ibv_config_wrapper::py_memory_regions)
+        .def_readwrite("interface_address", &udp_ibv_config_wrapper::py_interface_address)
         .def_property("buffer_size",
-                      SPEAD2_PTMF(udp_ibv_stream_config_wrapper, get_buffer_size),
-                      SPEAD2_PTMF_VOID(udp_ibv_stream_config_wrapper, set_buffer_size))
+                      SPEAD2_PTMF(udp_ibv_config_wrapper, get_buffer_size),
+                      SPEAD2_PTMF_VOID(udp_ibv_config_wrapper, set_buffer_size))
         .def_property("ttl",
-                      SPEAD2_PTMF(udp_ibv_stream_config_wrapper, get_ttl),
-                      SPEAD2_PTMF_VOID(udp_ibv_stream_config_wrapper, set_ttl))
+                      SPEAD2_PTMF(udp_ibv_config_wrapper, get_ttl),
+                      SPEAD2_PTMF_VOID(udp_ibv_config_wrapper, set_ttl))
         .def_property("comp_vector",
-                      SPEAD2_PTMF(udp_ibv_stream_config_wrapper, get_comp_vector),
-                      SPEAD2_PTMF_VOID(udp_ibv_stream_config_wrapper, set_comp_vector))
+                      SPEAD2_PTMF(udp_ibv_config_wrapper, get_comp_vector),
+                      SPEAD2_PTMF_VOID(udp_ibv_config_wrapper, set_comp_vector))
         .def_property("max_poll",
-                      SPEAD2_PTMF(udp_ibv_stream_config_wrapper, get_max_poll),
-                      SPEAD2_PTMF_VOID(udp_ibv_stream_config_wrapper, set_max_poll))
-        .def_readonly_static("DEFAULT_BUFFER_SIZE", &udp_ibv_stream_config_wrapper::default_buffer_size)
-        .def_readonly_static("DEFAULT_MAX_POLL", &udp_ibv_stream_config_wrapper::default_max_poll);
+                      SPEAD2_PTMF(udp_ibv_config_wrapper, get_max_poll),
+                      SPEAD2_PTMF_VOID(udp_ibv_config_wrapper, set_max_poll))
+        .def_readonly_static("DEFAULT_BUFFER_SIZE", &udp_ibv_config_wrapper::default_buffer_size)
+        .def_readonly_static("DEFAULT_MAX_POLL", &udp_ibv_config_wrapper::default_max_poll);
 
     {
         auto stream_class = udp_ibv_stream_register<udp_ibv_stream_wrapper<stream_wrapper<udp_ibv_stream>>>(m, "UdpIbvStream");

--- a/src/send_udp_ibv.cpp
+++ b/src/send_udp_ibv.cpp
@@ -143,7 +143,7 @@ public:
     udp_ibv_writer(
         io_service_ref io_service,
         const stream_config &config,
-        const udp_ibv_stream_config &udp_ibv_config);
+        const udp_ibv_stream_config &ibv_config);
 
     virtual std::size_t get_num_substreams() const override final { return endpoints.size(); }
 };
@@ -451,27 +451,27 @@ static std::size_t calc_target_batch(const stream_config &config, std::size_t n_
 udp_ibv_writer::udp_ibv_writer(
     io_service_ref io_service,
     const stream_config &config,
-    const udp_ibv_stream_config &udp_ibv_config)
+    const udp_ibv_stream_config &ibv_config)
     : writer(std::move(io_service), config),
-    n_slots(calc_n_slots(config, udp_ibv_config.get_buffer_size())),
+    n_slots(calc_n_slots(config, ibv_config.get_buffer_size())),
     target_batch(calc_target_batch(config, n_slots)),
     socket(get_io_service(), boost::asio::ip::udp::v4()),
-    endpoints(udp_ibv_config.get_endpoints()),
+    endpoints(ibv_config.get_endpoints()),
     event_channel(nullptr),
     comp_channel_wrapper(get_io_service()),
     available(n_slots),
-    max_poll(udp_ibv_config.get_max_poll())
+    max_poll(ibv_config.get_max_poll())
 {
     if (endpoints.empty())
         throw std::invalid_argument("endpoints is empty");
     mac_addresses.reserve(endpoints.size());
     for (const auto &endpoint : endpoints)
         mac_addresses.push_back(multicast_mac(endpoint.address()));
-    const boost::asio::ip::address &interface_address = udp_ibv_config.get_interface_address();
+    const boost::asio::ip::address &interface_address = ibv_config.get_interface_address();
     if (interface_address.is_unspecified())
         throw std::invalid_argument("interface address must be specified");
     // Check that registered memory regions don't overlap
-    auto config_regions = udp_ibv_config.get_memory_regions();
+    auto config_regions = ibv_config.get_memory_regions();
     std::sort(config_regions.begin(), config_regions.end());
     for (std::size_t i = 1; i < config_regions.size(); i++)
         if (static_cast<const std::uint8_t *>(config_regions[i - 1].first)
@@ -487,7 +487,7 @@ udp_ibv_writer::udp_ibv_writer(
     cm_id = rdma_cm_id_t(event_channel, nullptr, RDMA_PS_UDP);
     cm_id.bind_addr(interface_address);
     pd = ibv_pd_t(cm_id);
-    int comp_vector = udp_ibv_config.get_comp_vector();
+    int comp_vector = ibv_config.get_comp_vector();
     if (comp_vector >= 0)
     {
         comp_channel = ibv_comp_channel_t(cm_id);
@@ -516,7 +516,7 @@ udp_ibv_writer::udp_ibv_writer(
     std::shared_ptr<mmap_allocator> allocator = std::make_shared<mmap_allocator>(0, true);
     buffer = allocator->allocate(max_raw_size * n_slots, nullptr);
     mr = ibv_mr_t(pd, buffer.get(), buffer_size, IBV_ACCESS_LOCAL_WRITE);
-    for (const auto &region : udp_ibv_config.get_memory_regions())
+    for (const auto &region : ibv_config.get_memory_regions())
         memory_regions.emplace(pd, region.first, region.second);
     slots.reset(new slot[n_slots]);
     // We fill in the destination details for the first endpoint. If there are
@@ -536,7 +536,7 @@ udp_ibv_writer::udp_ibv_writer(
         // total_length will change later to the actual packet size
         ipv4.total_length(config.get_max_packet_size() + ipv4_packet::min_size + udp_packet::min_size);
         ipv4.flags_frag_off(ipv4_packet::flag_do_not_fragment);
-        ipv4.ttl(udp_ibv_config.get_ttl());
+        ipv4.ttl(ibv_config.get_ttl());
         ipv4.protocol(udp_packet::protocol);
         ipv4.source_address(interface_address.to_v4());
         ipv4.destination_address(endpoints[0].address().to_v4());
@@ -671,9 +671,9 @@ udp_ibv_stream::udp_ibv_stream(
 udp_ibv_stream::udp_ibv_stream(
     io_service_ref io_service,
     const stream_config &config,
-    const udp_ibv_stream_config &udp_ibv_config)
+    const udp_ibv_stream_config &ibv_config)
     : stream(std::unique_ptr<writer>(new udp_ibv_writer(
-        std::move(io_service), config, udp_ibv_config)))
+        std::move(io_service), config, ibv_config)))
 {
 }
 

--- a/src/send_udp_ibv.cpp
+++ b/src/send_udp_ibv.cpp
@@ -143,7 +143,7 @@ public:
     udp_ibv_writer(
         io_service_ref io_service,
         const stream_config &config,
-        const udp_ibv_stream_config &ibv_config);
+        const udp_ibv_config &ibv_config);
 
     virtual std::size_t get_num_substreams() const override final { return endpoints.size(); }
 };
@@ -451,7 +451,7 @@ static std::size_t calc_target_batch(const stream_config &config, std::size_t n_
 udp_ibv_writer::udp_ibv_writer(
     io_service_ref io_service,
     const stream_config &config,
-    const udp_ibv_stream_config &ibv_config)
+    const udp_ibv_config &ibv_config)
     : writer(std::move(io_service), config),
     n_slots(calc_n_slots(config, ibv_config.get_buffer_size())),
     target_batch(calc_target_batch(config, n_slots)),
@@ -561,20 +561,20 @@ static void validate_endpoint(const boost::asio::ip::udp::endpoint &endpoint)
         throw std::invalid_argument("endpoint is not an IPv4 multicast address");
 }
 
-static void validate_memory_region(const udp_ibv_stream_config::memory_region &region)
+static void validate_memory_region(const udp_ibv_config::memory_region &region)
 {
     if (region.second == 0)
         throw std::invalid_argument("memory region must have non-zero size");
 }
 
-constexpr std::size_t udp_ibv_stream_config::default_buffer_size;
-constexpr int udp_ibv_stream_config::default_max_poll;
+constexpr std::size_t udp_ibv_config::default_buffer_size;
+constexpr int udp_ibv_config::default_max_poll;
 
-udp_ibv_stream_config::udp_ibv_stream_config()
+udp_ibv_config::udp_ibv_config()
 {
 }
 
-udp_ibv_stream_config &udp_ibv_stream_config::set_endpoints(
+udp_ibv_config &udp_ibv_config::set_endpoints(
     const std::vector<boost::asio::ip::udp::endpoint> &endpoints)
 {
     for (const auto &endpoint : endpoints)
@@ -583,7 +583,7 @@ udp_ibv_stream_config &udp_ibv_stream_config::set_endpoints(
     return *this;
 }
 
-udp_ibv_stream_config &udp_ibv_stream_config::add_endpoint(
+udp_ibv_config &udp_ibv_config::add_endpoint(
     const boost::asio::ip::udp::endpoint &endpoint)
 {
     validate_endpoint(endpoint);
@@ -591,7 +591,7 @@ udp_ibv_stream_config &udp_ibv_stream_config::add_endpoint(
     return *this;
 }
 
-udp_ibv_stream_config &udp_ibv_stream_config::set_interface_address(
+udp_ibv_config &udp_ibv_config::set_interface_address(
     const boost::asio::ip::address &interface_address)
 {
     if (!interface_address.is_v4())
@@ -600,7 +600,7 @@ udp_ibv_stream_config &udp_ibv_stream_config::set_interface_address(
     return *this;
 }
 
-udp_ibv_stream_config &udp_ibv_stream_config::set_buffer_size(std::size_t buffer_size)
+udp_ibv_config &udp_ibv_config::set_buffer_size(std::size_t buffer_size)
 {
     if (buffer_size == 0)
         this->buffer_size = default_buffer_size;
@@ -609,19 +609,19 @@ udp_ibv_stream_config &udp_ibv_stream_config::set_buffer_size(std::size_t buffer
     return *this;
 }
 
-udp_ibv_stream_config &udp_ibv_stream_config::set_ttl(std::uint8_t ttl)
+udp_ibv_config &udp_ibv_config::set_ttl(std::uint8_t ttl)
 {
     this->ttl = ttl;
     return *this;
 }
 
-udp_ibv_stream_config &udp_ibv_stream_config::set_comp_vector(int comp_vector)
+udp_ibv_config &udp_ibv_config::set_comp_vector(int comp_vector)
 {
     this->comp_vector = comp_vector;
     return *this;
 }
 
-udp_ibv_stream_config &udp_ibv_stream_config::set_max_poll(int max_poll)
+udp_ibv_config &udp_ibv_config::set_max_poll(int max_poll)
 {
     if (max_poll < 1)
         throw std::invalid_argument("max_poll must be at least 1");
@@ -629,7 +629,7 @@ udp_ibv_stream_config &udp_ibv_stream_config::set_max_poll(int max_poll)
     return *this;
 }
 
-udp_ibv_stream_config &udp_ibv_stream_config::set_memory_regions(const std::vector<memory_region> &memory_regions)
+udp_ibv_config &udp_ibv_config::set_memory_regions(const std::vector<memory_region> &memory_regions)
 {
     for (const memory_region &region : memory_regions)
         validate_memory_region(region);
@@ -637,7 +637,7 @@ udp_ibv_stream_config &udp_ibv_stream_config::set_memory_regions(const std::vect
     return *this;
 }
 
-udp_ibv_stream_config &udp_ibv_stream_config::add_memory_region(const void *ptr, std::size_t size)
+udp_ibv_config &udp_ibv_config::add_memory_region(const void *ptr, std::size_t size)
 {
     memory_region region(ptr, size);
     validate_memory_region(region);
@@ -657,7 +657,7 @@ udp_ibv_stream::udp_ibv_stream(
     : udp_ibv_stream(
         std::move(io_service),
         config,
-        udp_ibv_stream_config()
+        udp_ibv_config()
             .add_endpoint(endpoint)
             .set_interface_address(interface_address)
             .set_buffer_size(buffer_size)
@@ -671,7 +671,7 @@ udp_ibv_stream::udp_ibv_stream(
 udp_ibv_stream::udp_ibv_stream(
     io_service_ref io_service,
     const stream_config &config,
-    const udp_ibv_stream_config &ibv_config)
+    const udp_ibv_config &ibv_config)
     : stream(std::unique_ptr<writer>(new udp_ibv_writer(
         std::move(io_service), config, ibv_config)))
 {

--- a/src/spead2/send/__init__.py
+++ b/src/spead2/send/__init__.py
@@ -22,7 +22,7 @@ from spead2._spead2.send import (       # noqa: F401
     RateMethod, StreamConfig, Heap, PacketGenerator,
     BytesStream, UdpStream, TcpStream, InprocStream)
 try:
-    from spead2._spead2.send import UdpIbvStream, UdpIbvStreamConfig      # noqa: F401
+    from spead2._spead2.send import UdpIbvStream, UdpIbvConfig      # noqa: F401
 except ImportError:
     pass
 

--- a/src/spead2/send/__init__.pyi
+++ b/src/spead2/send/__init__.pyi
@@ -135,7 +135,7 @@ class UdpStream(_UdpStream, _SyncStream):
                  config: StreamConfig = ...) -> None: ...
 
 
-class UdpIbvStreamConfig:
+class UdpIbvConfig:
     DEFAULT_BUFFER_SIZE: ClassVar[int]
     DEFAULT_MAX_POLL: ClassVar[int]
 
@@ -164,7 +164,7 @@ class UdpIbvStream(_SyncStream):
     @overload
     def __init__(self, thread_pool: spead2.ThreadPool,
                  config: StreamConfig,
-                 udp_ibv_config: UdpIbvStreamConfig) -> None: ...
+                 udp_ibv_config: UdpIbvConfig) -> None: ...
 
 
 class _TcpStream:

--- a/src/spead2/tools/cmdline.py
+++ b/src/spead2/tools/cmdline.py
@@ -203,7 +203,7 @@ class SenderOptions(_Options):
         if _HAVE_IBV:
             self.ibv = False
             self.ibv_vector = 0
-            self.ibv_max_poll = spead2.send.UdpIbvStreamConfig.DEFAULT_MAX_POLL
+            self.ibv_max_poll = spead2.send.UdpIbvConfig.DEFAULT_MAX_POLL
 
     def add_arguments(self, parser):
         def parse_rate_method(value):
@@ -250,7 +250,7 @@ class SenderOptions(_Options):
             if self._protocol.tcp:
                 self.buffer = spead2.send.asyncio.TcpStream.DEFAULT_BUFFER_SIZE
             elif _HAVE_IBV and self.ibv:
-                self.buffer = spead2.send.UdpIbvStreamConfig.DEFAULT_BUFFER_SIZE
+                self.buffer = spead2.send.UdpIbvConfig.DEFAULT_BUFFER_SIZE
             else:
                 self.buffer = spead2.send.asyncio.UdpStream.DEFAULT_BUFFER_SIZE
 
@@ -276,7 +276,7 @@ class SenderOptions(_Options):
             return spead2.send.asyncio.UdpIbvStream(
                 thread_pool,
                 config,
-                spead2.send.UdpIbvStreamConfig(
+                spead2.send.UdpIbvConfig(
                     endpoints=endpoints,
                     interface_address=self.bind or '',
                     buffer_size=self.buffer,

--- a/src/spead2_cmdline.cpp
+++ b/src/spead2_cmdline.cpp
@@ -360,8 +360,8 @@ std::unique_ptr<stream> sender_options::make_stream(
 #if SPEAD2_USE_IBV
         if (ibv)
         {
-            udp_ibv_stream_config udp_ibv_config;
-            udp_ibv_config
+            udp_ibv_stream_config ibv_config;
+            ibv_config
                 .set_endpoints(ep)
                 .set_interface_address(interface_address)
                 .set_memory_regions(memory_regions)
@@ -369,7 +369,7 @@ std::unique_ptr<stream> sender_options::make_stream(
                 .set_comp_vector(ibv_comp_vector)
                 .set_max_poll(ibv_max_poll)
                 .set_buffer_size(*buffer_size);
-            stream.reset(new udp_ibv_stream(io_service, config, udp_ibv_config));
+            stream.reset(new udp_ibv_stream(io_service, config, ibv_config));
         }
         else
 #endif // SPEAD2_USE_IBV

--- a/src/spead2_cmdline.cpp
+++ b/src/spead2_cmdline.cpp
@@ -303,7 +303,7 @@ void sender_options::notify(const protocol_options &protocol)
             buffer_size = tcp_stream::default_buffer_size;
 #if SPEAD2_USE_IBV
         else if (ibv)
-            buffer_size = udp_ibv_stream_config::default_buffer_size;
+            buffer_size = udp_ibv_config::default_buffer_size;
 #endif
         else
             buffer_size = udp_stream::default_buffer_size;
@@ -360,7 +360,7 @@ std::unique_ptr<stream> sender_options::make_stream(
 #if SPEAD2_USE_IBV
         if (ibv)
         {
-            udp_ibv_stream_config ibv_config;
+            udp_ibv_config ibv_config;
             ibv_config
                 .set_endpoints(ep)
                 .set_interface_address(interface_address)

--- a/src/spead2_cmdline.h
+++ b/src/spead2_cmdline.h
@@ -262,7 +262,7 @@ struct sender_options
 #if SPEAD2_USE_IBV
     bool ibv = false;
     int ibv_comp_vector = 0;
-    int ibv_max_poll = spead2::send::udp_ibv_stream_config::default_max_poll;
+    int ibv_max_poll = spead2::send::udp_ibv_config::default_max_poll;
 #endif
 
     void notify(const protocol_options &protocol);

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -471,7 +471,7 @@ class TestPassthroughUdpIbv(BaseTestPassthroughSubstreams):
             return spead2.send.UdpIbvStream(
                 thread_pool,
                 spead2.send.StreamConfig(rate=1e7),
-                spead2.send.UdpIbvStreamConfig(
+                spead2.send.UdpIbvConfig(
                     endpoints=[(self.MCAST_GROUP, 8876 + i) for i in range(n)],
                     interface_address=self._interface_address(),
                     buffer_size=64 * 1024
@@ -491,7 +491,7 @@ class TestPassthroughUdpIbv(BaseTestPassthroughSubstreams):
         sender = spead2.send.UdpIbvStream(
             spead2.ThreadPool(),
             spead2.send.StreamConfig(rate=1e7),
-            spead2.send.UdpIbvStreamConfig(
+            spead2.send.UdpIbvConfig(
                 endpoints=[(self.MCAST_GROUP, 8876)],
                 interface_address=self._interface_address(),
                 memory_regions=data

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -586,21 +586,21 @@ class TestInprocStream:
 
 
 @pytest.mark.skipif(not hasattr(spead2, 'IbvContext'), reason='IBV support not compiled in')
-class TestUdpIbvStreamConfig:
+class TestUdpIbvConfig:
     def test_default_construct(self):
-        config = spead2.send.UdpIbvStreamConfig()
+        config = spead2.send.UdpIbvConfig()
         assert config.endpoints == []
         assert config.interface_address == ''
-        assert config.buffer_size == spead2.send.UdpIbvStreamConfig.DEFAULT_BUFFER_SIZE
+        assert config.buffer_size == spead2.send.UdpIbvConfig.DEFAULT_BUFFER_SIZE
         assert config.ttl == 1
         assert config.comp_vector == 0
-        assert config.max_poll == spead2.send.UdpIbvStreamConfig.DEFAULT_MAX_POLL
+        assert config.max_poll == spead2.send.UdpIbvConfig.DEFAULT_MAX_POLL
         assert config.memory_regions == []
 
     def test_kwargs_construct(self):
         data1 = bytearray(10)
         data2 = bytearray(10)
-        config = spead2.send.UdpIbvStreamConfig(
+        config = spead2.send.UdpIbvConfig(
             endpoints=[('hello', 1234), ('goodbye', 2345)],
             interface_address='1.2.3.4',
             buffer_size=100,
@@ -617,12 +617,12 @@ class TestUdpIbvStreamConfig:
         assert config.memory_regions == [data1, data2]
 
     def test_default_buffer_size(self):
-        config = spead2.send.UdpIbvStreamConfig()
+        config = spead2.send.UdpIbvConfig()
         config.buffer_size = 0
-        assert config.buffer_size == spead2.send.UdpIbvStreamConfig.DEFAULT_BUFFER_SIZE
+        assert config.buffer_size == spead2.send.UdpIbvConfig.DEFAULT_BUFFER_SIZE
 
     def test_bad_max_poll(self):
-        config = spead2.send.UdpIbvStreamConfig()
+        config = spead2.send.UdpIbvConfig()
         with pytest.raises(ValueError):
             config.max_poll = 0
         with pytest.raises(ValueError):
@@ -631,7 +631,7 @@ class TestUdpIbvStreamConfig:
     def test_empty_memory_region(self):
         data = bytearray(0)
         config = spead2.send.StreamConfig()
-        udp_ibv_config = spead2.send.UdpIbvStreamConfig(
+        udp_ibv_config = spead2.send.UdpIbvConfig(
             endpoints=[('239.255.88.88', 8888)],
             interface_address='10.0.0.1',
             memory_regions=[data])
@@ -643,7 +643,7 @@ class TestUdpIbvStreamConfig:
         part1 = data[:6]
         part2 = data[5:]
         config = spead2.send.StreamConfig()
-        udp_ibv_config = spead2.send.UdpIbvStreamConfig(
+        udp_ibv_config = spead2.send.UdpIbvConfig(
             endpoints=[('239.255.88.88', 8888)],
             interface_address='10.0.0.1',
             memory_regions=[part1, part2])
@@ -652,13 +652,13 @@ class TestUdpIbvStreamConfig:
 
     def test_no_endpoints(self):
         config = spead2.send.StreamConfig()
-        udp_ibv_config = spead2.send.UdpIbvStreamConfig(interface_address='10.0.0.1')
+        udp_ibv_config = spead2.send.UdpIbvConfig(interface_address='10.0.0.1')
         with pytest.raises(ValueError, match='endpoints is empty'):
             spead2.send.UdpIbvStream(spead2.ThreadPool(), config, udp_ibv_config)
 
     def test_ipv6_endpoints(self):
         config = spead2.send.StreamConfig()
-        udp_ibv_config = spead2.send.UdpIbvStreamConfig(
+        udp_ibv_config = spead2.send.UdpIbvConfig(
             endpoints=[('::1', 8888)],
             interface_address='10.0.0.1')
         with pytest.raises(ValueError, match='endpoint is not an IPv4 multicast address'):
@@ -666,7 +666,7 @@ class TestUdpIbvStreamConfig:
 
     def test_unicast_endpoints(self):
         config = spead2.send.StreamConfig()
-        udp_ibv_config = spead2.send.UdpIbvStreamConfig(
+        udp_ibv_config = spead2.send.UdpIbvConfig(
             endpoints=[('10.0.0.1', 8888)],
             interface_address='10.0.0.1')
         with pytest.raises(ValueError, match='endpoint is not an IPv4 multicast address'):
@@ -674,14 +674,14 @@ class TestUdpIbvStreamConfig:
 
     def test_no_interface_address(self):
         config = spead2.send.StreamConfig()
-        udp_ibv_config = spead2.send.UdpIbvStreamConfig(
+        udp_ibv_config = spead2.send.UdpIbvConfig(
             endpoints=[('239.255.88.88', 8888)])
         with pytest.raises(ValueError, match='interface address'):
             spead2.send.UdpIbvStream(spead2.ThreadPool(), config, udp_ibv_config)
 
     def test_bad_interface_address(self):
         config = spead2.send.StreamConfig()
-        udp_ibv_config = spead2.send.UdpIbvStreamConfig(
+        udp_ibv_config = spead2.send.UdpIbvConfig(
             endpoints=[('239.255.88.88', 8888)],
             interface_address='this is not an interface address')
         with pytest.raises(RuntimeError, match='Host not found'):
@@ -689,7 +689,7 @@ class TestUdpIbvStreamConfig:
 
     def test_ipv6_interface_address(self):
         config = spead2.send.StreamConfig()
-        udp_ibv_config = spead2.send.UdpIbvStreamConfig(
+        udp_ibv_config = spead2.send.UdpIbvConfig(
             endpoints=[('239.255.88.88', 8888)],
             interface_address='::1')
         with pytest.raises(ValueError, match='interface address'):


### PR DESCRIPTION
And similarly for Python. Apart from being less typing, it's a slightly
better reflection as it configures the writer rather than the common
stream class.