### PR TITLE
Restore inproc_stream::get_queue

### DIFF
--- a/doc/migrate-3.rst
+++ b/doc/migrate-3.rst
@@ -86,10 +86,12 @@ A new feature is the ability to create a send stream with multiple destinations
 and select the destination on a per-heap basis (see :ref:`py-substreams` for
 more information). Supporting this cleanly required a number of changes:
 
-- The :attr:`spead2.send.InprocStream.queue` attribute has been removed, and replaced with
+- The :attr:`spead2.send.InprocStream.queue` attribute has been replaced with
   :attr:`~spead2.send.InprocStream.queues`. Similarly, the C++
   :cpp:func:`spead2::send::inproc_stream::get_queue` has been replaced by
-  :cpp:func:`~spead2::send::inproc_stream::get_queues`.
+  :cpp:func:`~spead2::send::inproc_stream::get_queues`. The originals are still
+  present but deprecated, and raise a :py:exc:`RuntimeError` if the stream was
+  constructed with multiple queues.
 - The constructors for most send stream types now accept a list of endpoints
   (or queues) rather than a single endpoint (queue). The old constructors are
   still supported for backwards compatibility, but are deprecated.

--- a/include/spead2/send_inproc.h
+++ b/include/spead2/send_inproc.h
@@ -60,6 +60,14 @@ public:
 
     /// Get the underlying storage queues
     const std::vector<std::shared_ptr<inproc_queue>> &get_queues() const;
+
+    /**
+     * Get the underlying storage queue (backwards compatibility).
+     *
+     * @throws runtime_error if there are multiple storage queues.
+     */
+    SPEAD2_DEPRECATED("use get_queues")
+    const std::shared_ptr<inproc_queue> &get_queue() const;
 };
 
 } // namespace send

--- a/src/py_send.cpp
+++ b/src/py_send.cpp
@@ -766,7 +766,15 @@ static py::class_<T> inproc_stream_register(py::module &m, const char *name)
              "thread_pool"_a, "queue"_a, "config"_a = stream_config())
         .def(py::init<std::shared_ptr<thread_pool_wrapper>, const std::vector<std::shared_ptr<inproc_queue>> &, const stream_config &>(),
              "thread_pool"_a, "queues"_a, "config"_a = stream_config())
-        .def_property_readonly("queues", SPEAD2_PTMF(T, get_queues));
+        .def_property_readonly("queues", SPEAD2_PTMF(T, get_queues))
+        .def_property_readonly("queue", [](const T &stream)
+        {
+            deprecation_warning("use queues");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+            return stream.get_queue();
+#pragma GCC diagnostic pop
+        });
 }
 
 template<typename T>

--- a/src/send_inproc.cpp
+++ b/src/send_inproc.cpp
@@ -148,5 +148,13 @@ const std::vector<std::shared_ptr<inproc_queue>> &inproc_stream::get_queues() co
     return static_cast<const inproc_writer &>(get_writer()).get_queues();
 }
 
+const std::shared_ptr<inproc_queue> &inproc_stream::get_queue() const
+{
+    const auto &queues = get_queues();
+    if (queues.size() != 1)
+        throw std::runtime_error("get_queue only works when there is a single queue. Use get_queues instead");
+    return queues[0];
+}
+
 } // namespace send
 } // namespace spead2

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -579,3 +579,18 @@ class TestPassthroughInproc(BaseTestPassthroughSubstreams):
         for queue in self._queues:
             queue.stop()
         return ret
+
+    def test_queues(self):
+        queues = [spead2.InprocQueue() for i in range(2)]
+        stream = spead2.send.InprocStream(spead2.ThreadPool(), queues)
+        assert stream.queues == queues
+        with pytest.deprecated_call():
+            with pytest.raises(RuntimeError):
+                stream.queue
+
+    def test_queue(self):
+        queue = spead2.InprocQueue()
+        stream = spead2.send.InprocStream(spead2.ThreadPool(), [queue])
+        assert stream.queues == [queue]
+        with pytest.deprecated_call():
+            assert stream.queue is queue


### PR DESCRIPTION
It was removed in favour of get_queues (due to substream support). I've
brought it back but marked it deprecated to ease the transition to 3.0.