### PR TITLE
Add --verify option to spead2_send and spead2_recv

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -35,6 +35,11 @@ Other changes:
   (with the default being ``AUTO``) so that it can later be re-enabled under
   circumstances where it is known to work well, while still allowing it to be
   explicitly enabled or disabled.
+- Add :option:`!--verify` option to :program:`spead2_send` and
+  :program:`spead2_recv` to aid in testing the code. To support this,
+  :program:`spead2_send` was modified so that each in-flight heap uses
+  different memory, which may reduce performance (due to less cache re-use)
+  even when the option is not given.
 
 Additionally, refer to the changes for 3.0.0b1 below.
 


### PR DESCRIPTION
It puts random data (created from a linear congruential generator) into
the data stream, and verifies it on the receive side. This can help with
testing issues that are missed by unit tests e.g. corner cases that only
affect a small number of heaps, or that require the buffer to be
recycled before they show up.