### PR TITLE
Replace allow_hw_rate with rate_method

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -31,7 +31,10 @@ Other changes:
 - Fix :program:`spead2_bench.py` ignoring the :option:`!--send-affinity` option.
 - The hardware rate limiting introduced in 3.0.0b1 is now disabled by default,
   as it proved to be significantly less accurate than the software rate limiter
-  in some cases.
+  in some cases. The interface has also been changed from a boolean to an enum
+  (with the default being ``AUTO``) so that it can later be re-enabled under
+  circumstances where it is known to work well, while still allowing it to be
+  explicitly enabled or disabled.
 
 Additionally, refer to the changes for 3.0.0b1 below.
 

--- a/doc/py-send.rst
+++ b/doc/py-send.rst
@@ -25,7 +25,8 @@ configuration between the stream classes, configuration is encapsulated in a
      transmission rate, the rate will be increased until the average rate
      has caught up. This value specifies the "catch-up" rate, as a ratio to the
      target rate.
-   :param bool allow_hw_rate: If true, then hardware-based rate
+   :param RateMethod rate_method: Select method for applying the rate limit.
+     If true, then hardware-based rate
      limiting may be used if available. In this case it is
      implementation-defined whether `burst_rate_ratio` and `burst_size` have
      any effect. This will often produce results that are at least as good as
@@ -33,6 +34,30 @@ configuration between the stream classes, configuration is encapsulated in a
      the overall rate becomes less accurate and so it is disabled by default.
 
    The constructor arguments are also instance attributes.
+
+.. py:class:: spead2.send.RateMethod
+
+   An enumeration to select a method for rate limiting.
+
+   .. attribute:: SW
+
+      Use a generic software rate limiter.
+
+   .. attribute:: HW
+
+      Use a hardware rate limiter, if available. This is currently only
+      supported when using :doc:`ibverbs <py-ibverbs>`, and only if the
+      hardware supports it. If hardware rate limiting is not available,
+      falls back to software.
+
+   .. attribute:: AUTO
+
+      This is the default, and lets the implementation decide whether to use
+      hardware rate limiting. At present it will never use the hardware rate
+      limiter (because the available hardware limiters don't do a good job
+      under all conditions), but in future it is likely to use the hardware
+      limiter more often in circumstances where it has been tested to perform
+      well.
 
 Streams send pre-baked heaps, which can be constructed by hand, but are more
 normally created from an :py:class:`~spead2.ItemGroup` by a

--- a/include/spead2/send_stream.h
+++ b/include/spead2/send_stream.h
@@ -43,6 +43,13 @@ namespace spead2
 namespace send
 {
 
+enum class rate_method
+{
+    SW,        ///< Software rate limiter
+    HW,        ///< Hardware rate limiter, if available
+    AUTO       ///< Implementation decides on rate-limit method
+};
+
 /**
  * Configuration for send streams.
  */
@@ -53,7 +60,7 @@ public:
     static constexpr std::size_t default_max_heaps = 4;
     static constexpr std::size_t default_burst_size = 65536;
     static constexpr double default_burst_rate_ratio = 1.05;
-    static constexpr bool default_allow_hw_rate = false;
+    static constexpr rate_method default_rate_method = rate_method::AUTO;
 
     /// Set maximum packet size to use (only counts the UDP payload, not L1-4 headers).
     stream_config &set_max_packet_size(std::size_t max_packet_size);
@@ -75,10 +82,10 @@ public:
     stream_config &set_burst_rate_ratio(double burst_rate_ratio);
     /// Get maximum increase in transmit rate for catching up.
     double get_burst_rate_ratio() const { return burst_rate_ratio; }
-    /// Set whether to allow hardware rate limiting.
-    stream_config &set_allow_hw_rate(bool allow_hw_rate);
-    /// Get whether to allow hardware rate limiting.
-    bool get_allow_hw_rate() const { return allow_hw_rate; }
+    /// Set rate-limiting method
+    stream_config &set_rate_method(rate_method method);
+    /// Get rate-limiting method
+    rate_method get_rate_method() const { return method; }
 
     /// Get product of rate and burst_rate_ratio
     double get_burst_rate() const;
@@ -91,7 +98,7 @@ private:
     std::size_t burst_size = default_burst_size;
     std::size_t max_heaps = default_max_heaps;
     double burst_rate_ratio = default_burst_rate_ratio;
-    bool allow_hw_rate = default_allow_hw_rate;
+    rate_method method = default_rate_method;
 };
 
 class writer;

--- a/src/py_send.cpp
+++ b/src/py_send.cpp
@@ -830,6 +830,11 @@ py::module register_module(py::module &parent)
         .def("__iter__", [](py::object self) { return self; })
         .def("__next__", &packet_generator_next);
 
+    py::enum_<rate_method>(m, "RateMethod")
+        .value("SW", rate_method::SW)
+        .value("HW", rate_method::HW)
+        .value("AUTO", rate_method::AUTO);
+
     py::class_<stream_config>(m, "StreamConfig")
         .def(py::init(&data_class_constructor<stream_config>))
         .def_property("max_packet_size",
@@ -847,16 +852,16 @@ py::module register_module(py::module &parent)
         .def_property("burst_rate_ratio",
                       SPEAD2_PTMF(stream_config, get_burst_rate_ratio),
                       SPEAD2_PTMF_VOID(stream_config, set_burst_rate_ratio))
-        .def_property("allow_hw_rate",
-                      SPEAD2_PTMF(stream_config, get_allow_hw_rate),
-                      SPEAD2_PTMF_VOID(stream_config, set_allow_hw_rate))
+        .def_property("rate_method",
+                      SPEAD2_PTMF(stream_config, get_rate_method),
+                      SPEAD2_PTMF_VOID(stream_config, set_rate_method))
         .def_property_readonly("burst_rate",
                                SPEAD2_PTMF(stream_config, get_burst_rate))
         .def_readonly_static("DEFAULT_MAX_PACKET_SIZE", &stream_config::default_max_packet_size)
         .def_readonly_static("DEFAULT_MAX_HEAPS", &stream_config::default_max_heaps)
         .def_readonly_static("DEFAULT_BURST_SIZE", &stream_config::default_burst_size)
         .def_readonly_static("DEFAULT_BURST_RATE_RATIO", &stream_config::default_burst_rate_ratio)
-        .def_readonly_static("DEFAULT_ALLOW_HW_RATE", &stream_config::default_allow_hw_rate);
+        .def_readonly_static("DEFAULT_RATE_METHOD", &stream_config::default_rate_method);
 
     {
         auto stream_class = udp_stream_register<udp_stream_wrapper<stream_wrapper<udp_stream>>>(m, "UdpStream");

--- a/src/send_stream.cpp
+++ b/src/send_stream.cpp
@@ -35,7 +35,7 @@ constexpr std::size_t stream_config::default_max_packet_size;
 constexpr std::size_t stream_config::default_max_heaps;
 constexpr std::size_t stream_config::default_burst_size;
 constexpr double stream_config::default_burst_rate_ratio;
-constexpr bool stream_config::default_allow_hw_rate;
+constexpr rate_method stream_config::default_rate_method;
 
 stream_config &stream_config::set_max_packet_size(std::size_t max_packet_size)
 {
@@ -74,9 +74,9 @@ stream_config &stream_config::set_burst_rate_ratio(double burst_rate_ratio)
     return *this;
 }
 
-stream_config &stream_config::set_allow_hw_rate(bool allow_hw_rate)
+stream_config &stream_config::set_rate_method(rate_method method)
 {
-    this->allow_hw_rate = allow_hw_rate;
+    this->method = method;
     return *this;
 }
 

--- a/src/send_udp_ibv.cpp
+++ b/src/send_udp_ibv.cpp
@@ -503,7 +503,11 @@ udp_ibv_writer::udp_ibv_writer(
     qp.modify(IBV_QPS_RTR);
     qp.modify(IBV_QPS_RTS);
 
-    if (config.get_allow_hw_rate() && config.get_rate() > 0.0)
+    /* For now AUTO is treated the same as SW; further investigation is
+     * needed to determine the conditions under which HW rate limiting
+     * behaves well.
+     */
+    if (config.get_rate_method() == rate_method::HW && config.get_rate() > 0.0)
     {
         if (setup_hw_rate(qp, config))
             enable_hw_rate();

--- a/src/send_writer.cpp
+++ b/src/send_writer.cpp
@@ -41,7 +41,7 @@ void writer::set_owner(stream *owner)
 
 void writer::enable_hw_rate()
 {
-    assert(config.get_allow_hw_rate());
+    assert(config.get_rate_method() != rate_method::SW);
     hw_rate = true;
 }
 

--- a/src/spead2/send/__init__.py
+++ b/src/spead2/send/__init__.py
@@ -19,7 +19,7 @@ import weakref
 
 import spead2 as _spead2
 from spead2._spead2.send import (       # noqa: F401
-    StreamConfig, Heap, PacketGenerator,
+    RateMethod, StreamConfig, Heap, PacketGenerator,
     BytesStream, UdpStream, TcpStream, InprocStream)
 try:
     from spead2._spead2.send import UdpIbvStream, UdpIbvStreamConfig      # noqa: F401

--- a/src/spead2/send/__init__.pyi
+++ b/src/spead2/send/__init__.pyi
@@ -16,6 +16,7 @@
 from typing import (
     Text, Union, List, Tuple, Iterator, Iterable, Optional, Sequence, ClassVar, overload
 )
+import enum
 import socket
 
 import spead2
@@ -40,24 +41,29 @@ class PacketGenerator:
     def __init__(self, heap: Heap, cnt: int, max_packet_size: int) -> None: ...
     def __iter__(self) -> Iterator[bytes]: ...
 
+class RateMethod(enum.Enum):
+    SW = ...
+    HW = ...
+    AUTO = ...
+
 class StreamConfig:
     DEFAULT_MAX_PACKET_SIZE: ClassVar[int]
     DEFAULT_MAX_HEAPS: ClassVar[int]
     DEFAULT_BURST_SIZE: ClassVar[int]
     DEFAULT_BURST_RATE_RATIO: ClassVar[float]
-    DEFAULT_ALLOW_HW_RATE: ClassVar[bool]
+    DEFAULT_RATE_METHOD: ClassVar[RateMethod]
 
     max_packet_size: int
     rate: float
     burst_size: int
     max_heaps: int
     burst_rate_ratio: float
-    allow_hw_rate: bool
+    rate_method: RateMethod
 
     def __init__(self, *, max_packet_size: int = ..., rate: float = ...,
                  burst_size: int = ..., max_heaps: int = ...,
                  burst_rate_ratio: float = ...,
-                 allow_hw_rate: bool = ...) -> None: ...
+                 rate_method: RateMethod = ...) -> None: ...
 
     @property
     def burst_rate(self) -> float: ...

--- a/src/spead2/tools/cmdline.py
+++ b/src/spead2/tools/cmdline.py
@@ -197,7 +197,7 @@ class SenderOptions(_Options):
         self.burst = spead2.send.StreamConfig.DEFAULT_BURST_SIZE
         self.burst_rate_ratio = spead2.send.StreamConfig.DEFAULT_BURST_RATE_RATIO
         self.max_heaps = spead2.send.StreamConfig.DEFAULT_MAX_HEAPS
-        self.allow_hw_rate = False
+        self.rate_method = spead2.send.StreamConfig.DEFAULT_RATE_METHOD
         self.rate = 0.0
         self.ttl = None
         if _HAVE_IBV:
@@ -206,6 +206,14 @@ class SenderOptions(_Options):
             self.ibv_max_poll = spead2.send.UdpIbvStreamConfig.DEFAULT_MAX_POLL
 
     def add_arguments(self, parser):
+        def parse_rate_method(value):
+            try:
+                return spead2.send.RateMethod.__members__[value.upper()]
+            except KeyError as exc:
+                raise ValueError from exc
+
+        rate_method_names = list(spead2.send.RateMethod.__members__)
+
         self._add_argument(parser, 'addr_bits', type=int,
                            help='Heap address bits [%(default)s]')
         self._add_argument(parser, 'packet', type=int,
@@ -218,8 +226,8 @@ class SenderOptions(_Options):
                            help='Hard rate limit, relative to --rate [%(default)s]')
         self._add_argument(parser, 'max_heaps', metavar='HEAPS', type=int,
                            help='Maximum heaps in flight [%(default)s]')
-        self._add_argument(parser, 'allow_hw_rate', action='store_true',
-                           help='Use hardware rate limiting if available')
+        self._add_argument(parser, 'rate_method', metavar='METHOD', type=parse_rate_method,
+                           help=f'Method for rate limiting ({"/".join(rate_method_names)})')
         self._add_argument(parser, 'rate', metavar='Gb/s', type=float,
                            help='Transmission rate bound [no limit]')
         self._add_argument(parser, 'ttl', type=int, help='TTL for multicast target')
@@ -257,7 +265,7 @@ class SenderOptions(_Options):
             burst_size=self.burst,
             burst_rate_ratio=self.burst_rate_ratio,
             max_heaps=self.max_heaps,
-            allow_hw_rate=self.allow_hw_rate)
+            rate_method=self.rate_method)
 
     async def make_stream(self, thread_pool, endpoints, memory_regions):
         config = self.make_stream_config()

--- a/src/spead2_cmdline.cpp
+++ b/src/spead2_cmdline.cpp
@@ -260,6 +260,34 @@ void receiver_options::add_readers(
 namespace send
 {
 
+std::ostream &operator<<(std::ostream &o, rate_method method)
+{
+    switch (method)
+    {
+    case rate_method::SW: return o << "SW";
+    case rate_method::HW: return o << "HW";
+    case rate_method::AUTO: return o << "AUTO";
+    }
+    return o;  // unreachable
+}
+
+std::istream &operator>>(std::istream &i, rate_method &method)
+{
+    std::string name;
+    if (i >> name)
+    {
+        if (name == "SW" || name == "sw")
+            method = rate_method::SW;
+        else if (name == "HW" || name == "hw")
+            method = rate_method::HW;
+        else if (name == "AUTO" || name == "auto")
+            method = rate_method::AUTO;
+        else
+            i.setstate(std::ios::failbit | std::ios::badbit);
+    }
+    return i;
+}
+
 void sender_options::notify(const protocol_options &protocol)
 {
 #if SPEAD2_USE_IBV
@@ -297,7 +325,7 @@ stream_config sender_options::make_stream_config() const
         .set_burst_size(burst_size)
         .set_burst_rate_ratio(burst_rate_ratio)
         .set_max_heaps(max_heaps)
-        .set_allow_hw_rate(allow_hw_rate);
+        .set_rate_method(method);
 }
 
 std::unique_ptr<stream> sender_options::make_stream(

--- a/src/spead2_cmdline.h
+++ b/src/spead2_cmdline.h
@@ -40,6 +40,7 @@
 #include <vector>
 #include <map>
 #include <utility>
+#include <iosfwd>
 #include <cassert>
 #include <boost/asio.hpp>
 #include <boost/program_options.hpp>
@@ -241,6 +242,10 @@ struct receiver_options
 namespace send
 {
 
+// These are needed for boost::program_options to parse/print rate_method
+std::ostream &operator<<(std::ostream &o, rate_method method);
+std::istream &operator>>(std::istream &i, rate_method &method);
+
 /// Command-line options for senders
 struct sender_options
 {
@@ -251,7 +256,7 @@ struct sender_options
     std::size_t burst_size = spead2::send::stream_config::default_burst_size;
     double burst_rate_ratio = spead2::send::stream_config::default_burst_rate_ratio;
     std::size_t max_heaps = spead2::send::stream_config::default_max_heaps;
-    bool allow_hw_rate = false;
+    rate_method method = spead2::send::stream_config::default_rate_method;
     double rate = 0.0;
     int ttl = 1;
 #if SPEAD2_USE_IBV
@@ -272,7 +277,7 @@ struct sender_options
         callback("burst", "Burst size", &burst_size);
         callback("burst-rate-ratio", "Hard rate limit, relative to --rate", &burst_rate_ratio);
         callback("max-heaps", "Maximum heaps in flight", &max_heaps);
-        callback("allow-hw-rate", "Use hardware rate limiting if available", &allow_hw_rate);
+        callback("rate-method", "Rate limiting method (SW/HW/AUTO)", &method);
         callback("rate", "Transmission rate bound (Gb/s)", &rate);
         callback("ttl", "TTL for multicast target", &ttl);
 #if SPEAD2_USE_IBV

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -449,7 +449,7 @@ class TestStreamConfig:
         assert config.burst_size == config.DEFAULT_BURST_SIZE
         assert config.max_heaps == config.DEFAULT_MAX_HEAPS
         assert config.burst_rate_ratio == config.DEFAULT_BURST_RATE_RATIO
-        assert config.allow_hw_rate == config.DEFAULT_ALLOW_HW_RATE
+        assert config.rate_method == config.DEFAULT_RATE_METHOD
 
     def test_setters(self):
         config = send.StreamConfig()
@@ -458,13 +458,13 @@ class TestStreamConfig:
         config.burst_size = 12345
         config.max_heaps = 5
         config.burst_rate_ratio = 1.5
-        config.allow_hw_rate = False
+        config.rate_method = send.RateMethod.SW
         assert config.max_packet_size == 1234
         assert config.rate == 1e9
         assert config.burst_size == 12345
         assert config.max_heaps == 5
         assert config.burst_rate_ratio == 1.5
-        assert config.allow_hw_rate is False
+        assert config.rate_method == send.RateMethod.SW
         assert config.burst_rate == 1.5e9
 
     def test_construct_kwargs(self):


### PR DESCRIPTION
This allows for more than 2 options. An AUTO option is the default, but
currently is the same as SW (until further investigation of where the
ConnectX-5 rate limiter does and doesn't behave well).