### PR TITLE
Avoid running arena initialisation on the hot path

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -40,6 +40,7 @@ Other changes:
   :program:`spead2_send` was modified so that each in-flight heap uses
   different memory, which may reduce performance (due to less cache re-use)
   even when the option is not given.
+- Miscellaneous performance improvements.
 
 Additionally, refer to the changes for 3.0.0b1 below.
 

--- a/src/common_thread_pool.cpp
+++ b/src/common_thread_pool.cpp
@@ -37,6 +37,13 @@ static void run_io_service(boost::asio::io_service &io_service)
 {
     try
     {
+        /* Glibc's memory allocator seems to do some initialisation the
+         * first time a thread does a dynamic allocation. To avoid that
+         * occurring in a real-time situation, do a dummy allocation now to
+         * initialise it.
+         */
+        int *dummy = new int;
+        delete dummy;
         io_service.run();
     }
     catch (const std::exception &e)


### PR DESCRIPTION
Profiling revealed that glibc initialises an arena the first time
dynamic allocation is one in a thread, and that this was happening when
the first packet arrived. To avoid that, do a dummy initialisation as
soon as the worker thread starts.