### PR TITLE
Lock the correct lock when sending a heap.

### DIFF
--- a/src/send_stream.cpp
+++ b/src/send_stream.cpp
@@ -149,7 +149,7 @@ bool stream::async_send_heap(const heap &h, completion_handler handler,
     }
     item_pointer_t cnt_mask = (item_pointer_t(1) << h.get_flavour().get_heap_address_bits()) - 1;
 
-    std::unique_lock<std::mutex> lock(head_mutex);
+    std::unique_lock<std::mutex> lock(tail_mutex);
     std::size_t tail = queue_tail.load(std::memory_order_relaxed);
     std::size_t head = queue_head.load(std::memory_order_acquire);
     if (tail - head == queue_size)


### PR DESCRIPTION
It was locking the head mutex when it should have locked the tail mutex.
I discovered this when a race condition caused sending to stop, I'm
guessing because of a race condition on need_wakeup causing a wakeup to
get lost. But there would probably have been other entertaining race
conditions too.