### PR TITLE
Improve send performance by eliminating a memory allocation

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+.. rubric:: Development version
+
+- Improve send performance by eliminating a memory allocation from packet
+  generation.
+
 .. rubric:: 3.1.1
 
 - Set ``IBV_ACCESS_RELAXED_ORDERING`` flag on ibverbs memory regions. This

--- a/include/spead2/send_packet.h
+++ b/include/spead2/send_packet.h
@@ -81,8 +81,20 @@ private:
 public:
     packet_generator(const heap &h, item_pointer_t cnt, std::size_t max_packet_size);
 
+    std::size_t get_max_packet_size() const;
+
     bool has_next_packet() const;
-    packet next_packet();
+    /**
+     * Create a packet ready for sending on the network. The caller must
+     * provide space for storing data, of size at least the @a max_packet_size
+     * passed to the constructor, and with at least item_pointer_t alignment.
+     * The returned buffer sequence may contain a mix of pointers to the
+     * original heap and pointers within the scratch area.
+     *
+     * If there are no more packets to send for the heap, an empty list is
+     * returned.
+     */
+    std::vector<boost::asio::const_buffer> next_packet(std::uint8_t *scratch);
 };
 
 } // namespace send

--- a/include/spead2/send_packet.h
+++ b/include/spead2/send_packet.h
@@ -35,24 +35,6 @@ namespace send
 
 class heap;
 
-/**
- * A packet ready for sending on the network. It contains some internally
- * held data, and const buffer sequence that contains a mix of pointers to
- * the internal data and pointers to the heap's items.
- *
- * If @a buffers is empty, it indicates the end of the heap.
- *
- * @todo Investigate whether number of new calls could be reduced by using
- * a pool for the case of packets with no item pointers other than the
- * per-packet ones; or by having the caller of the packet_generator provide
- * storage.
- */
-struct packet
-{
-    std::unique_ptr<std::uint8_t[]> data;
-    std::vector<boost::asio::const_buffer> buffers;
-};
-
 class packet_generator
 {
 private:

--- a/include/spead2/send_packet.h
+++ b/include/spead2/send_packet.h
@@ -42,36 +42,49 @@ private:
     static constexpr std::size_t prefix_size = 8 + 4 * sizeof(item_pointer_t);
 
     const heap &h;
-    item_pointer_t cnt;
-    std::size_t max_packet_size;
-    std::size_t max_item_pointers_per_packet;
+    const item_pointer_t cnt;
+    const std::size_t max_packet_size;
+    const std::size_t max_item_pointers_per_packet;
 
+    /// @name Item pointer generation
+    /// @{
     /// Next item pointer to send
     std::size_t next_item_pointer = 0;
+    /// Address at which payload for the next item will be found
+    std::size_t next_address = 0;
+    /// @}
+
+    /// @name Payload generation
+    /// @{
     /// Current item payload being sent
     std::size_t next_item = 0;
     /// Amount of next_item already sent
     std::size_t next_item_offset = 0;
-    /// Address at which payload for the next item will be found
-    std::size_t next_address = 0;
     /// Payload offset for the next packet
     s_item_pointer_t payload_offset = 0;
     s_item_pointer_t payload_size = 0;
+    /// @}
     /// There is payload padding, so we need to add a NULL item pointer
     bool need_null_item = false;
 
 public:
     packet_generator(const heap &h, item_pointer_t cnt, std::size_t max_packet_size);
 
+    /**
+     * The maximum size of a packet this generator will generate. It may be
+     * smaller than the value passed to the constructor (for alignment
+     * reasons), but will never be larger.
+     */
     std::size_t get_max_packet_size() const;
 
     bool has_next_packet() const;
     /**
      * Create a packet ready for sending on the network. The caller must
-     * provide space for storing data, of size at least the @a max_packet_size
-     * passed to the constructor, and with at least item_pointer_t alignment.
-     * The returned buffer sequence may contain a mix of pointers to the
-     * original heap and pointers within the scratch area.
+     * provide space for storing data, of size at least
+     * @ref get_max_packet_size, and with at least @c item_pointer_t alignment.
+     * The first element of the returned buffer sequence will reference a
+     * prefix of @a scratch, while the remaining elements will reference to the
+     * items of the original heap.
      *
      * If there are no more packets to send for the heap, an empty list is
      * returned.

--- a/include/spead2/send_writer.h
+++ b/include/spead2/send_writer.h
@@ -154,7 +154,7 @@ private:
 protected:
     struct transmit_packet
     {
-        packet pkt;
+        std::vector<boost::asio::const_buffer> buffers;
         std::size_t size;
         std::size_t substream_index;
         bool last;          // if this is the last packet in the group
@@ -174,9 +174,9 @@ protected:
     /**
      * Retrieve a packet from the stream.
      *
-     * If successful, the packet information is written into @ref data.
+     * If successful, the packet information is written into @a data.
      */
-    packet_result get_packet(transmit_packet &data);
+    packet_result get_packet(transmit_packet &data, std::uint8_t *scratch);
 
     /// Notify the base class that @a n groups have finished transmission.
     void groups_completed(std::size_t n);

--- a/src/py_send.cpp
+++ b/src/py_send.cpp
@@ -81,11 +81,12 @@ flavour heap_wrapper::get_flavour() const
 
 py::bytes packet_generator_next(packet_generator &gen)
 {
-    packet pkt = gen.next_packet();
-    if (pkt.buffers.empty())
+    std::unique_ptr<std::uint8_t[]> scratch(new std::uint8_t[gen.get_max_packet_size()]);
+    auto buffers = gen.next_packet(scratch.get());
+    if (buffers.empty())
         throw py::stop_iteration();
-    return py::bytes(std::string(boost::asio::buffers_begin(pkt.buffers),
-                                 boost::asio::buffers_end(pkt.buffers)));
+    return py::bytes(std::string(boost::asio::buffers_begin(buffers),
+                                 boost::asio::buffers_end(buffers)));
 }
 
 static py::object make_io_error(const boost::system::error_code &ec)

--- a/src/send_packet.cpp
+++ b/src/send_packet.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 #include <cstdint>
 #include <cstring>
+#include <climits>
 #include <stdexcept>
 #include <algorithm>
 #include <spead2/send_heap.h>
@@ -45,10 +46,13 @@ static bool use_immediate(const item &it, std::size_t max_immediate_size)
 
 packet_generator::packet_generator(
     const heap &h, item_pointer_t cnt, std::size_t max_packet_size)
-    : h(h), cnt(cnt), max_packet_size(max_packet_size)
-{
+    : h(h), cnt(cnt),
     // Round down max packet size so that we can align payload
-    max_packet_size &= ~7;
+    max_packet_size(max_packet_size &= ~7),
+    max_item_pointers_per_packet(
+        (max_packet_size - (prefix_size + sizeof(item_pointer_t))) / sizeof(item_pointer_t)
+    )
+{
     /* We need
      * - the prefix
      * - an item pointer
@@ -59,7 +63,7 @@ packet_generator::packet_generator(
         throw std::invalid_argument("packet size is too small");
 
     payload_size = 0;
-    const std::size_t max_immediate_size = h.get_flavour().get_heap_address_bits() / 8;
+    const std::size_t max_immediate_size = h.get_flavour().get_heap_address_bits() / CHAR_BIT;
     for (const item &it : h.items)
     {
         if (!use_immediate(it, max_immediate_size))
@@ -68,10 +72,8 @@ packet_generator::packet_generator(
 
     /* Check if we need to add dummy payload to ensure that every packet
      * contains some payload.
-     */
-    max_item_pointers_per_packet =
-        (max_packet_size - (prefix_size + sizeof(item_pointer_t))) / sizeof(item_pointer_t);
-    /* Number of packets needed to send all the item pointers, plus
+     *
+     * Number of packets needed to send all the item pointers, plus
      * potentially one extra in case we need to inject a NULL item pointer
      * to mark the separation between the padding and the last item.
      */
@@ -115,13 +117,14 @@ std::vector<boost::asio::const_buffer> packet_generator::next_packet(std::uint8_
     if (payload_offset < payload_size)
     {
         pointer_encoder encoder(h.get_flavour().get_heap_address_bits());
-        const std::size_t max_immediate_size = h.get_flavour().get_heap_address_bits() / 8;
+        const std::size_t max_immediate_size = h.get_flavour().get_heap_address_bits() / CHAR_BIT;
         const std::size_t n_item_pointers = std::min(
             max_item_pointers_per_packet,
             h.items.size() + need_null_item - next_item_pointer);
         std::size_t packet_payload_length = std::min(
             std::size_t(payload_size - payload_offset),
             max_packet_size - n_item_pointers * sizeof(item_pointer_t) - prefix_size);
+        assert(packet_payload_length > 0);
 
         // This code will need fixing up for alignment if item_pointer_t is ever
         // not 8 bytes.
@@ -138,6 +141,7 @@ std::vector<boost::asio::const_buffer> packet_generator::next_packet(std::uint8_
         *pointer++ = htobe<item_pointer_t>(encoder.encode_immediate(HEAP_LENGTH_ID, payload_size));
         *pointer++ = htobe<item_pointer_t>(encoder.encode_immediate(PAYLOAD_OFFSET_ID, payload_offset));
         *pointer++ = htobe<item_pointer_t>(encoder.encode_immediate(PAYLOAD_LENGTH_ID, packet_payload_length));
+        payload_offset += packet_payload_length;
         for (std::size_t i = 0; i < n_item_pointers; i++)
         {
             item_pointer_t ip;
@@ -168,10 +172,9 @@ std::vector<boost::asio::const_buffer> packet_generator::next_packet(std::uint8_
             *pointer++ = ip;
             next_item_pointer++;
         }
-        out.emplace_back(scratch, prefix_size + sizeof(item_pointer_t) * n_item_pointers);
+        out.emplace_back(scratch, prefix_size + 8 * n_item_pointers);
 
         // Generate payload
-        payload_offset += packet_payload_length;
         while (packet_payload_length > 0)
         {
             if (next_item == h.items.size())
@@ -180,7 +183,11 @@ std::vector<boost::asio::const_buffer> packet_generator::next_packet(std::uint8_
                 assert(need_null_item);
                 assert(packet_payload_length <= 8);
                 *pointer = 0;
-                out.emplace_back(pointer, packet_payload_length);
+                // We can only add dummy payload if there was no real payload,
+                // so we can merge this with the existing buffer.
+                assert(out.size() == 1);
+                out[0] = boost::asio::const_buffer(
+                    scratch, boost::asio::buffer_size(out[0]) + packet_payload_length);
                 packet_payload_length = 0;
             }
             else if (use_immediate(h.items[next_item], max_immediate_size))

--- a/src/send_writer.cpp
+++ b/src/send_writer.cpp
@@ -73,7 +73,7 @@ void writer::update_send_time_empty()
     send_time = std::max(send_time, backdate);
 }
 
-writer::packet_result writer::get_packet(transmit_packet &data)
+writer::packet_result writer::get_packet(transmit_packet &data, std::uint8_t *scratch)
 {
     if (must_sleep)
     {
@@ -106,8 +106,8 @@ writer::packet_result writer::get_packet(transmit_packet &data)
     detail::queue_item *cur = get_owner()->get_queue(active);
     assert(cur->gen.has_next_packet());
 
-    data.pkt = cur->gen.next_packet();
-    data.size = boost::asio::buffer_size(data.pkt.buffers);
+    data.buffers = cur->gen.next_packet(scratch);
+    data.size = boost::asio::buffer_size(data.buffers);
     data.substream_index = cur->substream_index;
     // Point at the start of the group, so that errors and byte counts accumulate
     // in one place.


### PR DESCRIPTION
Instead of packet_generator::next_packet allocate memory to store data that it can't reference in place (the SPEAD header and item pointers), require the caller to provide memory for this. The caller can allocate memory for each packet in flight and recycle it.

A bonus benefit is that for the ibv sender, the packet generator will write the SPEAD header and item pointers directly into the payload area where it is needed, avoiding the need to copy it.

This improves send performance with 1KB packets roughly from 64 -> 86 Gb/s.