### PR TITLE
Fix a use-after-free bug that could crash after send::stream::~stream

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,8 @@ Changelog
 
 .. rubric:: Development version
 
+- Fix a use-after-free bug that could cause a crash when freeing a send
+  stream.
 - Improve send performance by eliminating a memory allocation from packet
   generation.
 

--- a/include/spead2/send_writer.h
+++ b/include/spead2/send_writer.h
@@ -190,6 +190,10 @@ protected:
     /**
      * Request @ref wakeup when new packets become available (new relative
      * to the last call to @ref get_packet).
+     *
+     * Note: if this is called and there are no heaps whose callbacks are
+     * still outstanding, this writer may be immediately destroyed by another
+     * thread.
      */
     void request_wakeup();
 


### PR DESCRIPTION
The udp_ibv writer (and possibly others) might still have callbacks
scheduled after flush() returned.