### PR TITLE
Fix a memory leak when receiving with ibverbs

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 - Make the ibverbs sender compatible with `PeerDirect`_.
 - Add examples programs showing integration with `gdrcopy`_ and
   `PeerDirect`_.
+- Fix a memory leak when receiving with ibverbs.
 
 .. _gdrcopy: https://github.com/NVIDIA/gdrcopy
 .. _PeerDirect: https://docs.mellanox.com/pages/viewpage.action?pageId=32413288

--- a/include/spead2/recv_udp_ibv.h
+++ b/include/spead2/recv_udp_ibv.h
@@ -108,7 +108,6 @@ protected:
     ibv_pd_t pd;
     ibv_comp_channel_t comp_channel;
     boost::asio::posix::stream_descriptor comp_channel_wrapper;
-    std::vector<ibv_flow_t> flows;
 
     ///< Maximum supported packet size
     const std::size_t max_size;
@@ -275,9 +274,14 @@ private:
 
     // All the data structures required by ibverbs
     ibv_cq_t send_cq;
+    ibv_cq_t recv_cq;
     ibv_qp_t qp;
     ibv_mr_t mr;
-    ibv_cq_t recv_cq;
+    /* Note: don't try to move this to the base class, even though it is
+     * shared with udp_ibv_reader_mprq. It needs to be destroyed before the
+     * QP, otherwise destroying the QP fails with EBUSY.
+     */
+    std::vector<ibv_flow_t> flows;
 
     ///< Number of packets that can be queued
     const std::size_t n_slots;

--- a/include/spead2/recv_udp_ibv_mprq.h
+++ b/include/spead2/recv_udp_ibv_mprq.h
@@ -57,11 +57,12 @@ private:
     friend class detail::udp_ibv_reader_base<udp_ibv_mprq_reader>;
 
     // All the data structures required by ibverbs
+    ibv_cq_ex_t recv_cq;
     ibv_wq_mprq_t wq;
     ibv_rwq_ind_table_t rwq_ind_table;
     ibv_qp_t qp;
     ibv_mr_t mr;
-    ibv_cq_ex_t recv_cq;
+    std::vector<ibv_flow_t> flows;
 
     /// Data buffer for all the packets
     memory_allocator::pointer buffer;


### PR DESCRIPTION
The destruction order was wrong. Trying to destroy ibverbs objects that
are still referenced by other objects fails with EBUSY. The completion
queue buffer can be quite substantial (e.g. 128MB).