### PR TITLE
Use 'python3' everywhere to invoke Python

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-AC_INIT([spead2], m4_esyscmd([python gen/get_version.py full]))
+AC_INIT([spead2], m4_esyscmd([python3 gen/get_version.py full]))
 # Suppress the default CXXFLAGS
 : ${CXXFLAGS=""}
 AC_CONFIG_AUX_DIR([build-aux])
@@ -241,10 +241,10 @@ AM_CONDITIONAL([SPEAD2_USE_IBV], [test "x$SPEAD2_USE_IBV" = "x1"])
 AM_CONDITIONAL([SPEAD2_USE_CUDA], [test "x$SPEAD2_USE_CUDA" = "x1"])
 AM_CONDITIONAL([SPEAD2_USE_GDRAPI], [test "x$SPEAD2_USE_GDRAPI" = "x1"])
 
-AC_SUBST(SPEAD2_MAJOR, m4_esyscmd([python gen/get_version.py major]))
-AC_SUBST(SPEAD2_MINOR, m4_esyscmd([python gen/get_version.py minor]))
-AC_SUBST(SPEAD2_PATCH, m4_esyscmd([python gen/get_version.py patch]))
-AC_SUBST(SPEAD2_VERSION, m4_esyscmd([python gen/get_version.py full]))
+AC_SUBST(SPEAD2_MAJOR, m4_esyscmd([python3 gen/get_version.py major]))
+AC_SUBST(SPEAD2_MINOR, m4_esyscmd([python3 gen/get_version.py minor]))
+AC_SUBST(SPEAD2_PATCH, m4_esyscmd([python3 gen/get_version.py patch]))
+AC_SUBST(SPEAD2_VERSION, m4_esyscmd([python3 gen/get_version.py full]))
 
 AC_CONFIG_FILES([Makefile
                  src/Makefile

--- a/examples/test_recv.py
+++ b/examples/test_recv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2015, 2020 National Research Foundation (SARAO)
 #

--- a/examples/test_send.py
+++ b/examples/test_send.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2015, 2020 National Research Foundation (SARAO)
 #

--- a/examples/test_send_asyncio.py
+++ b/examples/test_send_asyncio.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2015, 2019-2020 National Research Foundation (SARAO)
 #

--- a/gen/gen_loader.py
+++ b/gen/gen_loader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-2020 National Research Foundation (SARAO)
 #

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2015, 2017, 2019-2020 National Research Foundation (SARAO)
 #


### PR DESCRIPTION
Out of the box, Ubuntu 20.04 has a /usr/bin/python3 but no
/usr/bin/python (and on older distributions, /usr/bin/python in Python
2). While virtual environments are preferred, using python3 for scripts
makes it possible to bootstrap and compile spead2 for C++ without
knowing much of anything about Python.