### PR TITLE
Add pipe option to CXXFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,7 @@ AC_LANG(C++)
 ### Check for -std=c++11
 
 save_CXXFLAGS="$CXXFLAGS"
-CXXFLAGS="-std=c++11 $CXXFLAGS"
+CXXFLAGS="-std=c++11 $CXXFLAGS -pipe"
 SPEAD2_CHECK_FEATURE([compiler_cxx11], [-std=c++11], [unordered_map], [], [std::unordered_map<int, int> m], [],
                      [AC_MSG_ERROR([C++11 support is required])])
 CXXFLAGS="$save_CXXFLAGS"


### PR DESCRIPTION
This makes compilation somewhat more speedious because you can use make
with the -j flag more effectively on multicore servers.

I am not familiar with the autoconf way of doing things so I may have in my
naivete done this wrong somehow. But it seems to work.