### PR TITLE
Fix mem_reader to stop gracefully

### DIFF
--- a/src/recv_mem.cpp
+++ b/src/recv_mem.cpp
@@ -38,7 +38,8 @@ mem_reader::mem_reader(
     get_io_service().post([this] {
         mem_to_stream(get_stream_base(), this->ptr, this->length);
         // There will be no more data, so we can stop the stream immediately.
-        get_stream_base().stop();
+        stream_base::add_packet_state state(get_stream_base());
+        state.stop();
         stopped();
     });
 }


### PR DESCRIPTION
Previously it was directly calling `stop` on the stream. This is
equivalent to the user calling it, which is normally a hard stop e.g. if
it is a ring_stream, it will stop the ringbuffer without pushing any
incomplete heaps into it, or whatever flushing a subclass has
implemented in its `stop_received` overload.

Instead, use `add_packet_state.stop`, which is what's normally called
for a stop triggered by the stream itself (for example, a stop heap or
end-of-file in a pcap file), which indirectly calls `stop_received` on
the stream.