### PR TITLE
Redesign deleter for memory_allocator::pointer

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,11 @@ Changelog
   statistics. This is a **backwards-incompatible change** (keep in mind that
   chunking receive is still experimental). Code that uses
   :cpp:class:`spead2::recv::chunk_ring_stream` is unaffected.
+- Change the design of deleters for
+  :cpp:class:`spead2::memory_allocator`. Code that calls ``get_user`` or
+  ``get_deleter`` on a pointer allocated by spead2 may now get a ``nullptr``
+  back. Code that uses a custom memory allocator and that calls these
+  functions on pointers allocated by that allocator should continue to work.
 - Allow a ready callback to be used together with
   :cpp:class:`spead2::recv::chunk_ring_stream`, to finish preparation of a
   chunk before it pushed to the ringbuffer.

--- a/doc/cpp-recv-chunk.rst
+++ b/doc/cpp-recv-chunk.rst
@@ -27,7 +27,7 @@ C++ API.
    :members:
 
 .. doxygenclass:: spead2::recv::chunk_stream
-   :members: chunk_stream, get_chunk_config
+   :members: chunk_stream, get_chunk_config, get_heap_metadata
 
 Ringbuffer convenience API
 --------------------------

--- a/doc/cpp-recv.rst
+++ b/doc/cpp-recv.rst
@@ -91,6 +91,9 @@ the first one.
 .. doxygenclass:: spead2::memory_allocator
    :members: allocate, free
 
+.. doxygenclass:: spead2::memory_allocator::deleter
+   :members:
+
 The file :file:`examples/gdrapi_example.cu` in the spead2 source distribution
 shows an example of using a custom memory allocator to allocate memory for
 heaps on the GPU.

--- a/include/spead2/common_memory_allocator.h
+++ b/include/spead2/common_memory_allocator.h
@@ -1,4 +1,4 @@
-/* Copyright 2016 National Research Foundation (SARAO)
+/* Copyright 2016, 2021 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -37,26 +37,69 @@ class memory_allocator;
  */
 class memory_allocator : public std::enable_shared_from_this<memory_allocator>
 {
-public:
-    class deleter
+private:
+    // Function object for backwards compatibility. It keeps a shared pointer
+    // to the allocator alive and calls its free function.
+    class legacy_deleter
     {
     private:
-        // Prevent copying, to guarantee that the shared_ptr moves with the wrapped pointer
-        deleter(const deleter &) = delete;
-        deleter &operator=(const deleter &) = delete;
+        struct state_t
+        {
+            std::shared_ptr<memory_allocator> allocator;
+            void *user;
 
-        std::shared_ptr<memory_allocator> allocator;
-        void *user;
+            state_t(std::shared_ptr<memory_allocator> &&allocator, void *user)
+                : allocator(std::move(allocator)), user(user) {}
+        };
+
+        /* The state needs to be held behind an additional pointer indirection
+         * to allow the call operator to be const and still reset the shared_ptr
+         * to the allocator. And it can't be held by unique_ptr because
+         * std::function is copyable. Potentially it could be held by raw
+         * pointer, but as it is not expected to actually be copied there should
+         * be relatively little overhead in using shared_ptr.
+         */
+        std::shared_ptr<state_t> state;
     public:
-        deleter() = default;
-        explicit deleter(std::shared_ptr<memory_allocator> allocator, void *user = nullptr);
-        // Allow moving
-        deleter(deleter &&) noexcept = default;
-        deleter &operator=(deleter &&) noexcept = default;
-        void operator()(std::uint8_t *ptr);
+        legacy_deleter() = default;
+        legacy_deleter(std::shared_ptr<memory_allocator> &&allocator, void *user);
+        void operator()(std::uint8_t *ptr) const;  ///< Call the allocator to free the memory
 
-        const std::shared_ptr<memory_allocator> &get_allocator() const { return allocator; }
-        void *get_user() const { return user; }
+        const std::shared_ptr<memory_allocator> &get_allocator() const { return state->allocator; }
+        void *get_user() const { return state->user; }
+    };
+
+public:
+    /**
+     * Deleter for pointers allocated by this allocator.
+     *
+     * This class derives from @c std::function, so it can be constructed
+     * with any deleter at run time. In particular, this means that
+     * @c std::unique_ptr<std::uint8_t[], D> can be converted to
+     * @c memory_allocator::pointer for any deleter @c D.
+     *
+     * For backwards compatibility, it can also be constructed from a shared
+     * pointer to an allocator and an arbitrary void pointer, in which case the
+     * deletion is performed by calling @ref memory_allocator::free.
+     */
+    class deleter : public std::function<void(std::uint8_t *)>
+    {
+    public:
+        using std::function<void(std::uint8_t *)>::function;
+
+        explicit deleter(std::shared_ptr<memory_allocator> allocator, void *user = nullptr)
+            : std::function<void(std::uint8_t *)>(legacy_deleter(std::move(allocator), user)) {}
+
+        /**
+         * If the backwards-compatibility constructor was used, return the stored
+         * allocator. Otherwise, returns a null pointer.
+         */
+        const std::shared_ptr<memory_allocator> &get_allocator() const;
+        /**
+         * If the backwards-compatibility constructor was used, return the stored
+         * user pointer. Otherwise, returns a null pointer.
+         */
+        void *get_user() const;
     };
 
     typedef std::unique_ptr<std::uint8_t[], deleter> pointer;
@@ -67,11 +110,10 @@ public:
      * Allocate @a size bytes of memory. The default implementation uses @c new
      * and pre-faults the memory.
      *
-     * The pointer type includes a custom deleter that takes a
-     * <code>void *</code> argument, which will be passed to @ref free. This
-     * can be used to pass extra information that is needed to free the
-     * memory. It is guaranteed that the base class will set this to
-     * @c nullptr.
+     * The @c pointer type uses @ref memory_allocator::deleter as the deleter.
+     * If the memory needs to be freed by something other than
+     * <code>delete[]</code> then pass a function object when constructing the
+     * pointer.
      *
      * @param size         Number of bytes to allocate
      * @param hint         Usage-dependent extra information
@@ -85,7 +127,9 @@ protected:
 
 private:
     /**
-     * Free memory previously returned from @ref allocate.
+     * Free memory previously returned from @ref allocate. This is kept
+     * only for backwards compatibility, so that existing allocators that
+     * override it will continue to work.
      *
      * @param ptr          Value returned by @ref allocate
      * @param user         User-defined handle stored in the deleter by @ref allocate
@@ -126,9 +170,6 @@ public:
     explicit mmap_allocator(int flags = 0, bool prefer_huge = false);
 
     virtual pointer allocate(std::size_t size, void *hint) override;
-
-private:
-    virtual void free(std::uint8_t *ptr, void *user) override;
 };
 
 } // namespace spead2

--- a/include/spead2/py_common.h
+++ b/include/spead2/py_common.h
@@ -492,23 +492,6 @@ PTMFWrapperGen<T, Return, Class, Args...> ptmf_wrapper_type(Return (Class::*ptmf
 #define SPEAD2_PTMF_VOID(Class, Func) \
     (decltype(::spead2::detail::ptmf_wrapper_type<Class>(&Class::Func))::template make_wrapper_void<&Class::Func>())
 
-/**
- * Pseudo-allocator that wraps a Python object implementing the buffer
- * protocol. At present it only supports writable buffers. The allocation
- * hint must be a pointer to a @ref buffer_allocation, and it will also
- * be stored as the @c user_data in the deleter.
- */
-class buffer_allocator final : public memory_allocator
-{
-private:
-    virtual void free(std::uint8_t *ptr, void *user_data) override;
-
-public:
-    static std::shared_ptr<buffer_allocator> instance;
-
-    virtual pointer allocate(std::size_t size, void *hint) override;
-};
-
 } // namespace detail
 
 struct buffer_allocation
@@ -518,6 +501,12 @@ struct buffer_allocation
 
     explicit buffer_allocation(pybind11::buffer buf);
 };
+
+/**
+ * Get the buffer_allocation embedded in the deleter. If the pointer was not
+ * allocated by the type caster, return @c nullptr.
+ */
+buffer_allocation *get_buffer_allocation(const memory_allocator::pointer &ptr);
 
 } // namespace spead2
 

--- a/src/py_recv.cpp
+++ b/src/py_recv.cpp
@@ -852,7 +852,8 @@ py::module register_module(py::module &parent)
             {
                 if (value)
                 {
-                    auto alloc = static_cast<const spead2::buffer_allocation *>(value.get_deleter().get_user());
+                    auto *alloc = get_buffer_allocation(value);
+                    assert(alloc != nullptr);
                     c.present_size = alloc->buffer_info.size * alloc->buffer_info.itemsize;
                 }
                 else


### PR DESCRIPTION
Previously it held a shared_ptr reference to the allocator, and called
back to the allocator to free the memory via a virtual function.
This had a few disadvantages:

- The allocator had to be kept alive (and referenced) even when its
  state wasn't needed for deletion (which was pretty much all the time).
- You had to have an allocator class, which made it lots of work to
  convert a regular unique_ptr to a memory_allocator::pointer.
- Any additional state had to be crammed into a void*, which had low
  safety (raw pointer AND untyped).

Replace it all by having the deleter type derive from std::function.
There is still backwards-compatible support for custom allocators that
override `free` and/or expect to be able to call `get_allocator` and
`get_user` on the deleter, but the allocators defined by spead2 do not
use it.