### PR TITLE
Make stream_stats (C++) more closely mimic STL classes

### DIFF
--- a/doc/py-recv.rst
+++ b/doc/py-recv.rst
@@ -102,7 +102,7 @@ properties after construction.
 
       Get the index of statistic `name`.
 
-      :raises ValueError: if `name` is not a known statistic name
+      :raises IndexError: if `name` is not a known statistic name
 
    .. py:attribute:: stats
 

--- a/src/recv_stream.cpp
+++ b/src/recv_stream.cpp
@@ -85,7 +85,7 @@ static std::size_t get_stat_index_nothrow(
 /**
  * Get the index within @a stats corresponding to @a name.
  *
- * @throw std::invalid_argument if it is not present
+ * @throw std::out_of_range if it is not present
  */
 static std::size_t get_stat_index(
     const std::vector<stream_stat_config> &stats,
@@ -93,7 +93,7 @@ static std::size_t get_stat_index(
 {
     std::size_t ret = get_stat_index_nothrow(stats, name);
     if (ret == stats.size())
-        throw std::invalid_argument(name + " is not a known statistic name");
+        throw std::out_of_range(name + " is not a known statistic name");
     return ret;
 }
 
@@ -155,10 +155,20 @@ stream_stats::stream_stats(std::shared_ptr<std::vector<stream_stat_config>> conf
 
 std::uint64_t &stream_stats::operator[](const std::string &name)
 {
+    return at(name);
+}
+
+const std::uint64_t &stream_stats::operator[](const std::string &name) const
+{
+    return at(name);
+}
+
+std::uint64_t &stream_stats::at(const std::string &name)
+{
     return values[get_stat_index(*config, name)];
 }
 
-std::uint64_t stream_stats::operator[](const std::string &name) const
+const std::uint64_t &stream_stats::at(const std::string &name) const
 {
     return values[get_stat_index(*config, name)];
 }
@@ -171,6 +181,11 @@ stream_stats::iterator stream_stats::find(const std::string &name)
 stream_stats::const_iterator stream_stats::find(const std::string &name) const
 {
     return const_iterator(*this, get_stat_index_nothrow(*config, name));
+}
+
+std::size_t stream_stats::count(const std::string &name) const
+{
+    return get_stat_index_nothrow(*config, name) != values.size() ? 1 : 0;
 }
 
 stream_stats stream_stats::operator+(const stream_stats &other) const

--- a/src/unittest_recv_stream_stats.cpp
+++ b/src/unittest_recv_stream_stats.cpp
@@ -84,12 +84,16 @@ BOOST_AUTO_TEST_CASE(test_reverse_iteration)
 {
     spead2::recv::stream_stats stats;
     std::vector<std::string> names, rnames, crnames;
+    /* Uses (*it).first rather than it->first because libc++ doesn't like the
+     * latter with reverse iterators when dereferencing doesn't return an
+     * lvalue.
+     */
     for (auto it = stats.begin(); it != stats.end(); ++it)
-        names.push_back(it->first);
+        names.push_back((*it).first);
     for (auto it = stats.rbegin(); it != stats.rend(); ++it)
-        rnames.push_back(it->first);
+        rnames.push_back((*it).first);
     for (auto it = stats.crbegin(); it != stats.crend(); ++it)
-        crnames.push_back(it->first);
+        crnames.push_back((*it).first);
     std::reverse(rnames.begin(), rnames.end());
     BOOST_TEST(rnames == names);
     std::reverse(crnames.begin(), crnames.end());

--- a/tests/test_recv.py
+++ b/tests/test_recv.py
@@ -807,7 +807,7 @@ class TestStreamConfig:
         assert counter_index == base_index
         assert config.get_stat_index('counter') == counter_index
         assert config.get_stat_index('maximum') == maximum_index
-        with pytest.raises(ValueError):
+        with pytest.raises(IndexError):
             config.get_stat_index('does_not_exist')
         # Can't add duplicates
         with pytest.raises(ValueError):


### PR DESCRIPTION
- Add a whole bag of typedefs
- Add `count` and `at` methods
- Add reverse iterator functions
- Make indexing operations on a const stream_stats return a const
  reference instead of a value
- Make operator[] with unknown name throw std::out_of_range rather than
  std::invalid_argument, for consistency with `at` (in a std::map it
  creates a new element, but stream_stats doesn't allow elements to be
  added or removed).