### PR TITLE
Allow adding immediate to a heap by reference

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -17,6 +17,9 @@ Changelog
 - Allow a ready callback to be used together with
   :cpp:class:`spead2::recv::chunk_ring_stream`, to finish preparation of a
   chunk before it pushed to the ringbuffer.
+- In Python, avoid copying immediate items when given as 0-d arrays with dtype
+  ``>u8``. This makes it practical to pre-define heaps and later update their
+  values rather than creating new heap objects.
 
 .. rubric:: 3.4.0
 

--- a/doc/py-protocol.rst
+++ b/doc/py-protocol.rst
@@ -27,11 +27,17 @@ Mapping of SPEAD protocol to Python
   whose length will be computed from the size of the item, or zero if any
   other element of the shape is zero.
 
-When transmitting data, one case is handled specially: if the expected shape
-is one-dimensional, but the provided value is an instance of
-:py:class:`bytes`, :py:class:`str` or :py:class:`unicode`, it will be broken
-up into its individual characters. This is a convenience for sending
-variable-length strings.
+When transmitting data, a few cases are handled specially:
+
+* If the expected shape is one-dimensional, but the provided value is an
+  instance of :py:class:`bytes`, :py:class:`str` or :py:class:`unicode`, it
+  will be broken up into its individual characters. This is a convenience for
+  sending variable-length strings.
+* If the format is a single signed or unsigned integer whose number of bits
+  is less than 64 but a multiple of 8, and the value is a zero-dimensional
+  numpy array with dtype ``>u8``, the relevant bytes are referenced by the
+  heap. The value can later be updated and the same heap sent again without
+  creating a new :py:class:`~spead2.send.Heap` object.
 
 When receiving data, some transformations are made:
 


### PR DESCRIPTION
This simplifies the procedure for pre-building a heap and recycling it
with new values.