### PR TITLE
Fix copy constructor and assignment for stream_stats

### DIFF
--- a/include/spead2/recv_stream.h
+++ b/include/spead2/recv_stream.h
@@ -210,6 +210,15 @@ public:
     stream_stats(std::shared_ptr<std::vector<stream_stat_config>> config,
                  std::vector<std::uint64_t> values);
 
+    /* Copy constructor and copy assignment need to be implemented manually
+     * because of the embedded references. This will suppress the implicit
+     * move assignment (which would also be unsafe). The implicit move
+     * constructor is safe so we default it.
+     */
+    stream_stats(const stream_stats &other);
+    stream_stats &operator=(const stream_stats &other);
+    stream_stats(stream_stats &&other) = default;
+
     /// Get the configuration of the statistics
     const std::vector<stream_stat_config> &get_config() const { return *config; }
 

--- a/src/recv_stream.cpp
+++ b/src/recv_stream.cpp
@@ -153,6 +153,20 @@ stream_stats::stream_stats(std::shared_ptr<std::vector<stream_stat_config>> conf
     assert(this->config->size() == this->values.size());
 }
 
+stream_stats::stream_stats(const stream_stats &other)
+    : stream_stats(other.config, other.values)
+{
+}
+
+stream_stats &stream_stats::operator=(const stream_stats &other)
+{
+    if (config != other.config && *config != *other.config)
+        throw std::invalid_argument("config must match to assign stats");
+    for (std::size_t i = 0; i < values.size(); i++)
+        values[i] = other.values[i];
+    return *this;
+}
+
 std::uint64_t &stream_stats::operator[](const std::string &name)
 {
     return at(name);

--- a/src/unittest_recv_stream_stats.cpp
+++ b/src/unittest_recv_stream_stats.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <utility>
 #include <boost/test/unit_test.hpp>
 #include <spead2/recv_stream.h>
 
@@ -169,6 +170,43 @@ BOOST_AUTO_TEST_CASE(test_count)
     spead2::recv::stream_stats stats;
     BOOST_TEST(stats.count("heaps") == 1);
     BOOST_TEST(stats.count("missing") == 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_copy)
+{
+    spead2::recv::stream_stats stats1;
+    stats1.packets = 10;
+    spead2::recv::stream_stats stats2(stats1);
+    BOOST_TEST(&stats2.packets == &stats2["packets"]);
+    stats1.packets = 20;
+    BOOST_TEST(stats2.packets == 10);
+}
+
+BOOST_AUTO_TEST_CASE(test_copy_assign)
+{
+    spead2::recv::stream_stats stats1, stats2;
+    stats1.packets = 10;
+    stats2 = stats1;
+    BOOST_TEST(stats2.packets == 10);
+    BOOST_TEST(&stats2.packets == &stats2["packets"]);
+}
+
+BOOST_AUTO_TEST_CASE(test_move)
+{
+    spead2::recv::stream_stats stats1;
+    stats1.packets = 10;
+    spead2::recv::stream_stats stats2(std::move(stats1));
+    BOOST_TEST(&stats2.packets == &stats2["packets"]);
+    BOOST_TEST(stats2.packets == 10);
+}
+
+BOOST_AUTO_TEST_CASE(test_move_assign)
+{
+    spead2::recv::stream_stats stats1, stats2;
+    stats1.packets = 10;
+    stats2 = std::move(stats1);
+    BOOST_TEST(stats2.packets == 10);
+    BOOST_TEST(&stats2.packets == &stats2["packets"]);
 }
 
 BOOST_AUTO_TEST_SUITE_END()  // stream_stats


### PR DESCRIPTION
For backwards compatibility, stream_stats contains reference members
pointing to some of the stats by name. These would have pointed to the
wrong place after copy construction (still pointing at the original
instead of the copy) and might have pointed to uninitialised memory
after assignment.