### PR TITLE
Fix gdrapi_example.cu

### DIFF
--- a/examples/gdrapi_example.cu
+++ b/examples/gdrapi_example.cu
@@ -166,12 +166,12 @@ void gdrapi_memory_allocator::deleter::operator()(std::uint8_t *ptr) const
 
 void *gdrapi_memory_allocator::get_device_ptr(const pointer &ptr)
 {
-    return ptr.get_deleter().target<deleter>()->dptr;
+    return spead2::memory_pool::get_base_deleter(ptr).target<deleter>()->dptr;
 }
 
 gdr_mh_t gdrapi_memory_allocator::get_mh(const pointer &ptr)
 {
-    return ptr.get_deleter().target<deleter>()->mh;
+    return spead2::memory_pool::get_base_deleter(ptr).target<deleter>()->mh;
 }
 
 /**

--- a/include/spead2/common_memory_pool.h
+++ b/include/spead2/common_memory_pool.h
@@ -86,6 +86,16 @@ public:
     bool get_warn_on_empty() const;
     void set_warn_on_empty(bool warn);
     virtual pointer allocate(std::size_t size, void *hint) override;
+
+    /**
+     * Get the underlying deleter.
+     *
+     * This is like <code>ptr.get_deleter()()</code>, but if the pointer is
+     * managed by the memory pool, it will fetch the deleter provided by the
+     * underlying allocator.
+     */
+    static const memory_allocator::deleter &get_base_deleter(const memory_allocator::pointer &ptr);
+    static memory_allocator::deleter &get_base_deleter(memory_allocator::pointer &ptr);
 };
 
 } // namespace spead2

--- a/src/unittest_memory_allocator.cpp
+++ b/src/unittest_memory_allocator.cpp
@@ -49,10 +49,12 @@ public:
 
     virtual pointer allocate(std::size_t size, void *hint) override
     {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Walloc-size-larger-than="
-        std::uint8_t *data = new std::uint8_t[size];
-#pragma GCC diagnostic pop
+        /* The size is copied to a volatile to outsmart the compiler, which
+         * sees that there is code that tries to allocate more than PTRDIFF_MAX
+         * elements (to test out-of-memory) and complains.
+         */
+        volatile std::size_t size_copy = size;
+        std::uint8_t *data = new std::uint8_t[size_copy];
         return pointer(data, deleter(shared_from_this(), hint));
     };
 

--- a/src/unittest_memory_allocator.cpp
+++ b/src/unittest_memory_allocator.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2016, 2019 National Research Foundation (SARAO)
+/* Copyright 2016, 2019, 2021 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -22,7 +22,9 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mpl/list.hpp>
+#include <vector>
 #include <memory>
+#include <utility>
 #include <spead2/common_memory_allocator.h>
 
 namespace spead2
@@ -40,7 +42,30 @@ public:
     huge_mmap_allocator() : spead2::mmap_allocator(0, true) {}
 };
 
-typedef boost::mpl::list<spead2::memory_allocator, spead2::mmap_allocator, huge_mmap_allocator> test_types;
+class legacy_allocator : public spead2::memory_allocator
+{
+public:
+    std::vector<std::pair<std::uint8_t *, void *>> deleted;
+
+    virtual pointer allocate(std::size_t size, void *hint) override
+    {
+        std::uint8_t *data = new std::uint8_t[size];
+        return pointer(data, deleter(shared_from_this(), hint));
+    };
+
+private:
+    virtual void free(std::uint8_t *ptr, void *user) override
+    {
+        delete[] ptr;
+        deleted.emplace_back(ptr, user);
+    }
+};
+
+typedef boost::mpl::list<
+    spead2::memory_allocator,
+    spead2::mmap_allocator,
+    huge_mmap_allocator,
+    legacy_allocator> test_types;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(allocator_test, T, test_types)
 {
@@ -57,6 +82,26 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(out_of_memory, T, test_types)
 {
     std::shared_ptr<T> allocator = std::make_shared<T>();
     BOOST_CHECK_THROW(allocator->allocate(SIZE_MAX - 1, nullptr), std::bad_alloc);
+}
+
+BOOST_AUTO_TEST_CASE(legacy)
+{
+    auto allocator = std::make_shared<legacy_allocator>();
+    auto ptr = allocator->allocate(123, nullptr);
+    BOOST_TEST(allocator->deleted.empty());
+    std::uint8_t *raw = ptr.get();
+    ptr.reset();
+    BOOST_TEST(allocator->deleted.size() == 1);
+    BOOST_TEST(allocator->deleted[0].first == raw);
+    BOOST_TEST(allocator->deleted[0].second == nullptr);
+
+    // Now a pointer with a non-null user value (set via hint)
+    ptr = allocator->allocate(234, &raw);
+    raw = ptr.get();
+    ptr.reset();
+    BOOST_TEST(allocator->deleted.size() == 2);
+    BOOST_TEST(allocator->deleted[1].first == raw);
+    BOOST_TEST(allocator->deleted[1].second == &raw);
 }
 
 BOOST_AUTO_TEST_SUITE_END()  // memory_allocator

--- a/src/unittest_memory_allocator.cpp
+++ b/src/unittest_memory_allocator.cpp
@@ -49,7 +49,10 @@ public:
 
     virtual pointer allocate(std::size_t size, void *hint) override
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Walloc-size-larger-than="
         std::uint8_t *data = new std::uint8_t[size];
+#pragma GCC diagnostic pop
         return pointer(data, deleter(shared_from_this(), hint));
     };
 

--- a/src/unittest_memory_pool.cpp
+++ b/src/unittest_memory_pool.cpp
@@ -70,6 +70,25 @@ public:
         void *ptr;
     };
 
+    struct deleter
+    {
+        std::shared_ptr<mock_allocator> allocator;
+        // ptr + 1, used to check that state is preserved with each pointer
+        std::uint8_t *next_ptr;
+
+        deleter(std::shared_ptr<mock_allocator> allocator, std::uint8_t *ptr)
+            : allocator(std::move(allocator)), next_ptr(ptr + 1)
+        {
+        }
+
+        void operator()(std::uint8_t *ptr) const
+        {
+            BOOST_CHECK_EQUAL(ptr + 1, next_ptr);
+            allocator->records.push_back(record{false, 0, ptr});
+            allocator->saved.emplace_back(ptr);
+        }
+    };
+
     std::vector<record> records;
     std::vector<std::unique_ptr<std::uint8_t[]>> saved;
 
@@ -78,15 +97,9 @@ public:
         (void) hint;
         std::uint8_t *ptr = new std::uint8_t[size];
         records.push_back(record{true, size, ptr});
-        return pointer(ptr, deleter(shared_from_this(), ptr - 1));
-    }
-
-private:
-    virtual void free(std::uint8_t *ptr, void *user) override
-    {
-        BOOST_CHECK_EQUAL(ptr - 1, user);
-        records.push_back(record{false, 0, ptr});
-        saved.emplace_back(ptr);
+        std::shared_ptr<mock_allocator> shared_this =
+            std::static_pointer_cast<mock_allocator>(shared_from_this());
+        return pointer(ptr, deleter(shared_this, ptr));
     }
 };
 
@@ -114,9 +127,8 @@ public:
     }
 };
 
-// Check that the user pointer is passed through to the underlying allocator,
-// and generally interacts with the underlying allocator correctly
-BOOST_AUTO_TEST_CASE(memory_pool_pass_user)
+// Check that the underlying deleter is preserved.
+BOOST_AUTO_TEST_CASE(memory_pool_pass_deleter)
 {
     typedef spead2::memory_allocator::pointer pointer;
     std::shared_ptr<mock_allocator> allocator = std::make_shared<mock_allocator>();
@@ -126,6 +138,10 @@ BOOST_AUTO_TEST_CASE(memory_pool_pass_user)
 
     // Pooled allocation, comes from the pre-allocated slot
     pointer p1 = pool->allocate(1536, nullptr);
+    mock_allocator::deleter *base_deleter;
+    base_deleter = spead2::memory_pool::get_base_deleter(p1).target<mock_allocator::deleter>();
+    BOOST_TEST_REQUIRE(base_deleter != nullptr);
+    BOOST_TEST(base_deleter->next_ptr == p1.get() + 1);
     // Pooled allocations, newly allocated
     pointer p2 = pool->allocate(1500, nullptr);
     pointer p3 = pool->allocate(1024, nullptr);
@@ -139,6 +155,9 @@ BOOST_AUTO_TEST_CASE(memory_pool_pass_user)
     pointer p4 = pool->allocate(1600, nullptr);
     // Allocation not from the pool
     pointer p5 = pool->allocate(2049, nullptr);
+    base_deleter = spead2::memory_pool::get_base_deleter(p5).target<mock_allocator::deleter>();
+    BOOST_TEST_REQUIRE(base_deleter != nullptr);
+    BOOST_TEST(base_deleter->next_ptr == p5.get() + 1);
 
     // Release our reference to the pool. It should be destroyed once p4 is freed
     pool.reset();

--- a/src/unittest_memory_pool.cpp
+++ b/src/unittest_memory_pool.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2016, 2017, 2019 National Research Foundation (SARAO)
+/* Copyright 2016, 2017, 2019, 2021 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free


### PR DESCRIPTION
It was updated but not tested (lack of hardware) when the memory
allocator API was changed. It broke because it tried to get the
gdrapi_memory_allocator::deleter from the pointer, but it was getting
the deleter for the memory pool.

Fixed by adding some API to memory_pool to allow the underlying deleter
to be retrieved.