### PR TITLE
Improve accuracy of rate limiter

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,6 +4,9 @@ Changelog
 .. rubric:: Development version
 
 - Drop support for Python 3.6, which has reached end-of-life.
+- Improve the accuracy of the rate limiter. Previously it could send
+  slightly too fast due to rounding sleep times to whole numbers of
+  nanoseconds.
 
 .. rubric:: 3.7.0
 


### PR DESCRIPTION
Previously it could be a bit off because wait times were rounded to
whole nanoseconds (or whatever the unit of high_resolution_clock is).
While the actual sleeps can only be this accurate, the residual errors
would accumulate and should eventually be corrected.

This is fixed by using a new precise_time class for internal time
calculations, that holds a time_point for the high resolution clock, and
a small correction term.
