### PR TITLE
Add substreams option for receivers

### DIFF
--- a/.ci/install-sys-pkgs.sh
+++ b/.ci/install-sys-pkgs.sh
@@ -14,7 +14,8 @@ if [ "$(uname -s)" = "Linux" ]; then
         libpcap-dev \
         libcap-dev \
         librdmacm-dev \
-        libibverbs-dev
+        libibverbs-dev \
+        libdivide-dev
 else
-    brew install autoconf automake boost ccache
+    brew install autoconf automake boost ccache libdivide
 fi

--- a/.ci/install-sys-pkgs.sh
+++ b/.ci/install-sys-pkgs.sh
@@ -17,5 +17,6 @@ if [ "$(uname -s)" = "Linux" ]; then
         libibverbs-dev \
         libdivide-dev
 else
-    brew install autoconf automake boost ccache libdivide
+    brew install autoconf automake boost ccache
+    wget https://raw.githubusercontent.com/ridiculousfish/libdivide/5.0/libdivide.h -O /usr/local/include/libdivide.h
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-# Copyright 2016, 2017, 2019-2020 National Research Foundation (SARAO)
+# Copyright 2016, 2017, 2019-2020, 2022 National Research Foundation (SARAO)
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -44,6 +44,8 @@ SPEAD2_CHECK_LIB([boost/system/system_error.hpp], [boost_system], [boost::system
                  [], [AC_MSG_ERROR([boost_system is required])])
 SPEAD2_CHECK_HEADER([boost/asio.hpp], [boost_system,pthread], [boost::asio::io_service io_service],
                     [], [AC_MSG_ERROR([boost_asio is required])])
+SPEAD2_CHECK_HEADER([libdivide.h], [], [libdivide::divider<unsigned long long> div],
+                    [], [AC_MSG_ERROR([libdivide is required])])
 
 ### Optional libraries/features
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+.. rubric:: Development version
+
+- Added ``substreams`` to :py:class:`spead2.recv.StreamConfig` to improve
+  handling of interleaved heaps from multiple senders.
+- Add libdivide to the dependencies.
+
 .. rubric:: 3.8.0
 
 - Drop support for Python 3.6, which has reached end-of-life.

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -73,18 +73,18 @@ Python install from source
 Installing from source requires a modern C++ compiler supporting C++11 (GCC
 4.8+ or Clang 3.5+, although only GCC 5.4 and Clang 3.8 are tested and support
 for older compilers may be dropped) as well as Boost (including compiled
-libraries) and the Python development headers. At the moment only GNU/Linux and
-OS X get tested but other POSIX-like systems should work too. There are no
-plans to support Windows.
+libraries), libdivide, and the Python development headers. At the moment only
+GNU/Linux and OS X get tested but other POSIX-like systems should work too.
+There are no plans to support Windows.
 
 Installation works with standard Python installation methods.
 
 Installing spead2 for C++
 -------------------------
 spead2 requires a modern C++ compiler supporting C++11 (see above for supported
-compilers) as well as Boost (including compiled libraries). At the moment only
-GNU/Linux and OS X get tested but other POSIX-like systems should work too.
-There are no plans to support Windows.
+compilers) as well as Boost (including compiled libraries) and libdivide. At
+the moment only GNU/Linux and OS X get tested but other POSIX-like systems
+should work too.  There are no plans to support Windows.
 
 The C++ API uses the standard autoconf installation flow i.e.:
 

--- a/doc/py-recv.rst
+++ b/doc/py-recv.rst
@@ -47,9 +47,14 @@ properties after construction.
 .. py:class:: spead2.recv.StreamConfig(**kwargs)
 
    :param int max_heaps:
-     The number of partial heaps that can be live at one time.
-     This affects how intermingled heaps can be (due to out-of-order packet
-     delivery) before heaps get dropped.
+     The number of partial heaps that can be live at one time,
+     per substream. This affects how intermingled heaps can be (due to
+     out-of-order packet delivery) before heaps get dropped.
+     See :ref:`py-packet-ordering` for details.
+   :param int substreams:
+     Set the number of parallel streams. The remainder when the heap cnt is
+     divided by this value is used to identify the substream. See
+     :ref:`py-packet-ordering` for details.
    :param int bug_compat:
      Bug compatibility flags (see :ref:`py-flavour`)
    :param int memcpy:
@@ -320,6 +325,15 @@ multiple senders. We consider two sorts of packet ordering issues:
    complete. When there are many producers it will likely to be necessary to
    increase this value. Larger values increase the memory usage for partial
    heaps, and have a small performance impact.
+
+   It's possible to get more predictable results when the producers
+   interleave their heap cnts (for example, by using
+   :py:meth:`spead2.send.Stream.set_cnt_sequence`) such that the remainder
+   when dividing the heap cnt by the number of producers identifies the
+   producer. In this case, set the :py:attr:`substreams` attribute of
+   :py:class:`spead2.recv.StreamConfig` to the number of producers. Note that
+   :py:attr:`max_heaps` applies separately to each producer, and can
+   usually be very low (1 or 2) if the producer sends one heap at a time.
 
 .. _py-memory-allocators:
 

--- a/manylinux/before_all.sh
+++ b/manylinux/before_all.sh
@@ -32,6 +32,9 @@ ninja-build -v install
 # See https://github.com/pypa/manylinux/issues/731
 cp /usr/share/aclocal/pkg.m4 /usr/local/share/aclocal/
 
+# Install libdivide
+wget https://raw.githubusercontent.com/ridiculousfish/libdivide/5.0/libdivide.h -O /usr/local/include/libdivide.h
+
 # Prepare for split debug symbols for the wheels
 cat <<EOF > "$package/setup.cfg"
 [build_ext]

--- a/src/py_recv.cpp
+++ b/src/py_recv.cpp
@@ -643,6 +643,9 @@ py::module register_module(py::module &parent)
         .def_property("max_heaps",
                       SPEAD2_PTMF(stream_config, get_max_heaps),
                       SPEAD2_PTMF(stream_config, set_max_heaps))
+        .def_property("substreams",
+                      SPEAD2_PTMF(stream_config, get_substreams),
+                      SPEAD2_PTMF(stream_config, set_substreams))
         .def_property("bug_compat",
                       SPEAD2_PTMF(stream_config, get_bug_compat),
                       SPEAD2_PTMF(stream_config, set_bug_compat))

--- a/src/recv_stream.cpp
+++ b/src/recv_stream.cpp
@@ -558,7 +558,6 @@ bool stream_base::add_packet(add_packet_state &state, const packet_header &packe
 
 void stream_base::flush_unlocked()
 {
-    const std::size_t max_heaps = get_config().get_max_heaps();
     const std::size_t num_substreams = get_config().get_substreams();
     std::size_t n_flushed = 0;
     for (std::size_t i = 0; i < num_substreams; i++)

--- a/src/recv_stream.cpp
+++ b/src/recv_stream.cpp
@@ -221,10 +221,10 @@ stream_stats &stream_stats::operator+=(const stream_stats &other)
 
 constexpr std::size_t stream_config::default_max_heaps;
 
-static std::size_t compute_bucket_count(std::size_t max_heaps)
+static std::size_t compute_bucket_count(std::size_t total_max_heaps)
 {
     std::size_t buckets = 4;
-    while (buckets < max_heaps)
+    while (buckets < total_max_heaps)
         buckets *= 2;
     buckets *= 4;    // Make sure the table has a low load factor
     return buckets;
@@ -266,6 +266,14 @@ stream_config &stream_config::set_max_heaps(std::size_t max_heaps)
     if (max_heaps == 0)
         throw std::invalid_argument("max_heaps cannot be 0");
     this->max_heaps = max_heaps;
+    return *this;
+}
+
+stream_config &stream_config::set_substreams(std::size_t substreams)
+{
+    if (substreams == 0)
+        throw std::invalid_argument("substreams cannot be 0");
+    this->substreams = substreams;
     return *this;
 }
 
@@ -366,24 +374,30 @@ std::size_t stream_config::get_stat_index(const std::string &name) const
 
 
 stream_base::stream_base(const stream_config &config)
-    : queue_storage(new storage_type[config.get_max_heaps()]),
-    bucket_count(compute_bucket_count(config.get_max_heaps())),
+    : queue_storage(new storage_type[config.get_max_heaps() * config.get_substreams()]),
+    bucket_count(compute_bucket_count(config.get_max_heaps() * config.get_substreams())),
     bucket_shift(compute_bucket_shift(bucket_count)),
     buckets(new queue_entry *[bucket_count]),
-    head(0),
+    substreams(new substream[config.get_substreams() + 1]),
+    substream_div(config.get_substreams()),
     config(config),
     stats(config.get_stats().size()),
     batch_stats(config.get_stats().size())
 {
-    for (std::size_t i = 0; i < config.get_max_heaps(); i++)
+    for (std::size_t i = 0; i < config.get_max_heaps() * config.get_substreams(); i++)
         cast(i)->next = INVALID_ENTRY;
     for (std::size_t i = 0; i < bucket_count; i++)
         buckets[i] = NULL;
+    for (std::size_t i = 0; i <= config.get_substreams(); i++)
+    {
+        substreams[i].start = i * config.get_max_heaps();
+        substreams[i].head = substreams[i].start;
+    }
 }
 
 stream_base::~stream_base()
 {
-    for (std::size_t i = 0; i < get_config().get_max_heaps(); i++)
+    for (std::size_t i = 0; i < get_config().get_max_heaps() * get_config().get_substreams(); i++)
     {
         queue_entry *entry = cast(i);
         if (entry->next != INVALID_ENTRY)
@@ -394,10 +408,16 @@ stream_base::~stream_base()
     }
 }
 
-std::size_t stream_base::get_bucket(s_item_pointer_t heap_cnt) const
+std::size_t stream_base::get_bucket(item_pointer_t heap_cnt) const
 {
     // Look up Fibonacci hashing for an explanation of the magic number
     return (heap_cnt * 11400714819323198485ULL) >> bucket_shift;
+}
+
+std::size_t stream_base::get_substream(item_pointer_t heap_cnt) const
+{
+    // libdivide doesn't provide operator %
+    return heap_cnt - (heap_cnt / substream_div * config.get_substreams());
 }
 
 stream_base::queue_entry *stream_base::cast(std::size_t index)
@@ -494,9 +514,11 @@ bool stream_base::add_packet(add_packet_state &state, const packet_header &packe
             return false;
         }
 
-        if (++head == config.get_max_heaps())
-            head = 0;
-        entry = cast(head);
+        std::size_t substream_id = get_substream(heap_cnt);
+        substream &ss = substreams[substream_id];
+        if (++ss.head == substreams[substream_id + 1].start)
+            ss.head = ss.start;
+        entry = cast(ss.head);
         if (entry->next != INVALID_ENTRY)
         {
             state.incomplete_heaps_evicted++;
@@ -537,18 +559,24 @@ bool stream_base::add_packet(add_packet_state &state, const packet_header &packe
 void stream_base::flush_unlocked()
 {
     const std::size_t max_heaps = get_config().get_max_heaps();
+    const std::size_t num_substreams = get_config().get_substreams();
     std::size_t n_flushed = 0;
-    for (std::size_t i = 0; i < max_heaps; i++)
+    for (std::size_t i = 0; i < num_substreams; i++)
     {
-        if (++head == max_heaps)
-            head = 0;
-        queue_entry *entry = cast(head);
-        if (entry->next != INVALID_ENTRY)
+        substream &ss = substreams[i];
+        const std::size_t end = substreams[i + 1].start;
+        for (std::size_t j = ss.start; j < end; j++)
         {
-            n_flushed++;
-            unlink_entry(entry);
-            heap_ready(std::move(entry->heap));
-            entry->heap.~live_heap();
+            if (++ss.head == substreams[i + 1].start)
+                ss.head = ss.start;
+            queue_entry *entry = cast(ss.head);
+            if (entry->next != INVALID_ENTRY)
+            {
+                n_flushed++;
+                unlink_entry(entry);
+                heap_ready(std::move(entry->heap));
+                entry->heap.~live_heap();
+            }
         }
     }
     std::lock_guard<std::mutex> stats_lock(stats_mutex);

--- a/src/send_writer.cpp
+++ b/src/send_writer.cpp
@@ -38,7 +38,7 @@ writer::precise_time::precise_time(const coarse_type &coarse)
 {
 }
 
-void writer::precise_time::precise_time::normalize()
+void writer::precise_time::normalize()
 {
     auto floor = std::chrono::duration_cast<coarse_type::duration>(correction);
     if (correction < floor)

--- a/src/spead2/recv/__init__.pyi
+++ b/src/spead2/recv/__init__.pyi
@@ -95,6 +95,7 @@ class StreamStats:
 class StreamConfig:
     DEFAULT_MAX_HEAPS: ClassVar[int] = ...
     max_heaps: int
+    substreams: int
     bug_compat: int
     memcpy: int
     memory_allocator: spead2.MemoryAllocator
@@ -104,7 +105,7 @@ class StreamConfig:
     stream_id: int
     @property
     def stats(self) -> List[StreamStatConfig]: ...
-    def __init__(self, *, max_heaps: int = ..., bug_compat: int = ...,
+    def __init__(self, *, max_heaps: int = ..., substreams: int = ..., bug_compat: int = ...,
                  memcpy: int = ..., memory_allocator: spead2.MemoryAllocator = ...,
                  stop_on_stop_item: bool = ..., allow_unsized_heaps: bool = ...,
                  allow_out_of_order: bool = ..., stream_id: int = ...) -> None: ...

--- a/src/spead2/tools/cmdline.py
+++ b/src/spead2/tools/cmdline.py
@@ -1,4 +1,4 @@
-# Copyright 2020 National Research Foundation (SARAO)
+# Copyright 2020, 2022 National Research Foundation (SARAO)
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -154,6 +154,7 @@ class ReceiverOptions(SharedOptions):
         super().__init__(protocol, name_map)
         self.memcpy_nt = False
         self.concurrent_heaps = spead2.recv.StreamConfig.DEFAULT_MAX_HEAPS
+        self.substreams = 1
         self.ring_heaps = spead2.recv.RingStreamConfig.DEFAULT_HEAPS
         self.mem_pool = False
         self.mem_lower = 16384
@@ -168,7 +169,9 @@ class ReceiverOptions(SharedOptions):
         self._add_argument(parser, 'memcpy_nt', action='store_true',
                            help='Use non-temporal memcpy')
         self._add_argument(parser, 'concurrent_heaps', type=int,
-                           help='Maximum number of in-flight heaps [%(default)s]')
+                           help='Maximum number of in-flight heaps per substream [%(default)s]')
+        self._add_argument(parser, 'substreams', type=int,
+                           help='Number of parallel substreams [%(default)s]')
         self._add_argument(parser, 'ring_heaps', type=int,
                            help='Ring buffer capacity in heaps [%(default)s]')
         self._add_argument(parser, 'mem_pool', action='store_true', help='Use a memory pool')
@@ -210,6 +213,7 @@ class ReceiverOptions(SharedOptions):
     def make_stream_config(self):
         config = spead2.recv.StreamConfig()
         config.max_heaps = self.concurrent_heaps
+        config.substreams = self.substreams
         config.bug_compat = spead2.BUG_COMPAT_PYSPEAD_0_5_2 if self._protocol.pyspead else 0
         if self.mem_pool:
             config.memory_allocator = spead2.MemoryPool(self.mem_lower, self.mem_upper,

--- a/src/spead2_cmdline.cpp
+++ b/src/spead2_cmdline.cpp
@@ -146,6 +146,7 @@ stream_config receiver_options::make_stream_config(const protocol_options &proto
 {
     stream_config config;
     config.set_max_heaps(max_heaps);
+    config.set_substreams(substreams);
     if (mem_pool)
     {
         std::shared_ptr<spead2::memory_pool> pool = std::make_shared<spead2::memory_pool>(

--- a/src/spead2_cmdline.h
+++ b/src/spead2_cmdline.h
@@ -179,6 +179,7 @@ struct receiver_options
     bool ring = false;
     bool memcpy_nt = false;
     std::size_t max_heaps = stream_config::default_max_heaps;
+    std::size_t substreams = 1;
     std::size_t ring_heaps = ring_stream_config::default_heaps;
     bool mem_pool = false;
     std::size_t mem_lower = 16384;
@@ -202,7 +203,8 @@ struct receiver_options
         callback("bind", "Interface address", &interface_address);
         callback("packet", "Maximum packet size to accept", &max_packet_size);
         callback("buffer", "Socket buffer size", &buffer_size);
-        callback("concurrent-heaps", "Maximum number of in-flight heaps", &max_heaps);
+        callback("concurrent-heaps", "Maximum number of in-flight heaps, per substream", &max_heaps);
+        callback("substreams", "Number of parallel substreams", &substreams);
         callback("ring-heaps", "Ring buffer capacity in heaps", &ring_heaps);
         callback("mem-pool", "Use a memory pool", &mem_pool);
         callback("mem-lower", "Minimum allocation which will use the memory pool", &mem_lower);

--- a/tests/test_recv.py
+++ b/tests/test_recv.py
@@ -506,9 +506,9 @@ class TestDecode:
         payload = bytearray(96)
         payload[:] = range(96)
         packets = self.flavour.make_packet_heap(1, [
-                Item(0x1600, 12345, True),
-                Item(0x5000, payload, False)],
-                packets=[(5, 12), (32, 64)])
+            Item(0x1600, 12345, True),
+            Item(0x5000, payload, False)],
+            packets=[(5, 12), (32, 64)])
         heaps = self.data_to_heaps(b''.join(packets),
                                    contiguous_only=False,
                                    incomplete_keep_payload_ranges=True,

--- a/tests/test_recv.py
+++ b/tests/test_recv.py
@@ -1,4 +1,4 @@
-# Copyright 2015, 2017, 2019-2021 National Research Foundation (SARAO)
+# Copyright 2015, 2017, 2019-2022 National Research Foundation (SARAO)
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -99,29 +99,59 @@ class Flavour:
                 raise ValueError('Shape must contain non-negative values and None')
         return b''.join(data)
 
-    def make_packet_heap(self, heap_cnt, items):
-        """Construct a single-packet heap."""
+    def make_packet_heap(self, heap_cnt, items, *, duplicate_item_pointers=False, packets=None):
+        """Construct all the packets in a heap.
+
+        The `packets` arguments can be
+
+        - None, to generate a single heap.
+        - An integer, to generate a list of heaps, with the payload evenly
+          split.
+        - A list of 2-tuples containing payload ranges, to generate a list of
+          packets containing those interals.
+        """
         payload_size = 0
         for item in items:
             if not item.immediate:
                 payload_size += len(bytes(item.value))
 
-        all_items = [
-            Item(spead2.HEAP_CNT_ID, heap_cnt, True),
-            Item(spead2.PAYLOAD_OFFSET_ID, 0, True),
-            Item(spead2.PAYLOAD_LENGTH_ID, payload_size, True),
-            Item(spead2.HEAP_LENGTH_ID, payload_size, True)]
-        offset = 0
+        if packets is None:
+            payload_ranges = [(0, payload_size)]
+        elif isinstance(packets, int):
+            payload_ranges = [
+                (i * payload_size // packets, (i + 1) * payload_size // packets)
+                for i in range(packets)
+            ]
+        else:
+            payload_ranges = packets
+
         payload = bytearray(payload_size)
+        item_ptrs = []
+        offset = 0
         for item in items:
             if not item.immediate:
                 value = bytes(item.value)
-                all_items.append(Item(item.id, value, offset=offset))
+                item_ptrs.append(Item(item.id, value, offset=offset))
                 payload[offset : offset + len(value)] = value
                 offset += len(value)
             else:
-                all_items.append(item)
-        return self.make_packet(all_items, payload)
+                item_ptrs.append(item)
+
+        out = []
+        for start, stop in payload_ranges:
+            packet_items = [
+                Item(spead2.HEAP_CNT_ID, heap_cnt, True),
+                Item(spead2.PAYLOAD_OFFSET_ID, start, True),
+                Item(spead2.PAYLOAD_LENGTH_ID, stop - start, True),
+                Item(spead2.HEAP_LENGTH_ID, payload_size, True)]
+            packet_items.extend(item_ptrs)
+            if not duplicate_item_pointers:
+                item_ptrs.clear()  # Only put them in the first packet
+            out.append(self.make_packet(packet_items, payload[start : stop]))
+        if packets is None:
+            return out[0]
+        else:
+            return out
 
     def make_plain_descriptor(self, id, name, description, format, shape):
         if not isinstance(name, bytes):
@@ -185,15 +215,16 @@ class TestDecode:
     def data_to_heaps(self, data, **kwargs):
         """Take some data and pass it through the receiver to obtain a set of heaps.
 
-        Keyword arguments are passed to the receiver constructor.
+        Keyword arguments are passed to the stream config.
         """
         thread_pool = spead2.ThreadPool()
         config = recv.StreamConfig(bug_compat=self.flavour.bug_compat)
         ring_config = recv.RingStreamConfig()
-        for key in ['stop_on_stop_item', 'allow_unsized_heaps', 'allow_out_of_order']:
+        for key in {'stop_on_stop_item', 'allow_unsized_heaps', 'allow_out_of_order',
+                    'max_heaps', 'substreams'}:
             if key in kwargs:
                 setattr(config, key, kwargs.pop(key))
-        for key in ['contiguous_only', 'incomplete_keep_payload_ranges']:
+        for key in {'contiguous_only', 'incomplete_keep_payload_ranges'}:
             if key in kwargs:
                 setattr(ring_config, key, kwargs.pop(key))
         if kwargs:
@@ -394,22 +425,10 @@ class TestDecode:
     def test_duplicate_item_pointers(self):
         payload = bytearray(64)
         payload[:] = range(64)
-        packets = [
-            self.flavour.make_packet([
-                Item(spead2.HEAP_CNT_ID, 1, True),
-                Item(spead2.PAYLOAD_OFFSET_ID, 0, True),
-                Item(spead2.PAYLOAD_LENGTH_ID, 32, True),
-                Item(spead2.HEAP_LENGTH_ID, 64, True),
-                Item(0x1600, 12345, True),
-                Item(0x5000, 0, False, offset=0)], payload[0 : 32]),
-            self.flavour.make_packet([
-                Item(spead2.HEAP_CNT_ID, 1, True),
-                Item(spead2.PAYLOAD_OFFSET_ID, 32, True),
-                Item(spead2.PAYLOAD_LENGTH_ID, 32, True),
-                Item(spead2.HEAP_LENGTH_ID, 64, True),
-                Item(0x1600, 12345, True),
-                Item(0x5000, 0, False, offset=0)], payload[32 : 64])
-        ]
+        packets = self.flavour.make_packet_heap(1, [
+            Item(0x1600, 12345, True),
+            Item(0x5000, payload, False)],
+            packets=2)
         heaps = self.data_to_heaps(b''.join(packets))
         assert len(heaps) == 1
         items = heaps[0].get_items()
@@ -425,20 +444,10 @@ class TestDecode:
     def test_out_of_order_packets(self):
         payload = bytearray(64)
         payload[:] = range(64)
-        packets = [
-            self.flavour.make_packet([
-                Item(spead2.HEAP_CNT_ID, 1, True),
-                Item(spead2.PAYLOAD_OFFSET_ID, 32, True),
-                Item(spead2.PAYLOAD_LENGTH_ID, 32, True),
-                Item(spead2.HEAP_LENGTH_ID, 64, True),
-                Item(0x1600, 12345, True),
-                Item(0x5000, 0, False, offset=0)], payload[32 : 64]),
-            self.flavour.make_packet([
-                Item(spead2.HEAP_CNT_ID, 1, True),
-                Item(spead2.PAYLOAD_OFFSET_ID, 0, True),
-                Item(spead2.PAYLOAD_LENGTH_ID, 32, True),
-                Item(spead2.HEAP_LENGTH_ID, 64, True)], payload[0 : 32])
-        ]
+        packets = self.flavour.make_packet_heap(1, [
+            Item(0x1600, 12345, True),
+            Item(0x5000, payload, False)],
+            packets=[(32, 64), (0, 32)])
         heaps = self.data_to_heaps(b''.join(packets), allow_out_of_order=True)
         assert len(heaps) == 1
         items = heaps[0].get_items()
@@ -454,20 +463,10 @@ class TestDecode:
     def test_out_of_order_disallowed(self):
         payload = bytearray(64)
         payload[:] = range(64)
-        packets = [
-            self.flavour.make_packet([
-                Item(spead2.HEAP_CNT_ID, 1, True),
-                Item(spead2.PAYLOAD_OFFSET_ID, 32, True),
-                Item(spead2.PAYLOAD_LENGTH_ID, 32, True),
-                Item(spead2.HEAP_LENGTH_ID, 64, True),
-                Item(0x1600, 12345, True),
-                Item(0x5000, 0, False, offset=0)], payload[32 : 64]),
-            self.flavour.make_packet([
-                Item(spead2.HEAP_CNT_ID, 1, True),
-                Item(spead2.PAYLOAD_OFFSET_ID, 0, True),
-                Item(spead2.PAYLOAD_LENGTH_ID, 32, True),
-                Item(spead2.HEAP_LENGTH_ID, 64, True)], payload[0 : 32])
-        ]
+        packets = self.flavour.make_packet_heap(1, [
+            Item(0x1600, 12345, True),
+            Item(0x5000, payload, False)],
+            packets=[(32, 64), (0, 32)])
         heaps = self.data_to_heaps(b''.join(packets),
                                    contiguous_only=False,
                                    incomplete_keep_payload_ranges=True)
@@ -478,23 +477,38 @@ class TestDecode:
         assert heaps[0].received_length == 32
         assert heaps[0].payload_ranges == [(0, 32)]
 
-    def test_incomplete_heaps(self):
+    def test_substreams(self):
         payload = bytearray(64)
         payload[:] = range(64)
-        packets = [
-            self.flavour.make_packet([
-                Item(spead2.HEAP_CNT_ID, 1, True),
-                Item(spead2.PAYLOAD_OFFSET_ID, 5, True),
-                Item(spead2.PAYLOAD_LENGTH_ID, 7, True),
-                Item(spead2.HEAP_LENGTH_ID, 96, True),
+        stream0_packets = self.flavour.make_packet_heap(2, [
+            Item(0x1600, 12345, True),
+            Item(0x5000, payload, False)],
+            packets=2)
+        stream1_packets = []
+        for i in range(3, 20, 2):
+            stream1_packets.extend(self.flavour.make_packet_heap(i, [
+                Item(0x1600, 54321, True),
+                Item(0x5001, payload, False)],
+                packets=2))
+        # Interleave the packets from stream 1 into the middle of the substream
+        # 0 packet.
+        packets = stream0_packets[0:1] + stream1_packets + stream0_packets[1:]
+        heaps = self.data_to_heaps(b''.join(packets), substreams=2)
+        assert len(heaps) == 10
+        assert heaps[-1].cnt == 2
+        items = heaps[-1].get_items()
+        assert len(items) == 2
+        items.sort(key=lambda item: item.id)
+        assert items[0].id == 0x1600
+        assert items[0].immediate_value == 12345
+
+    def test_incomplete_heaps(self):
+        payload = bytearray(96)
+        payload[:] = range(96)
+        packets = self.flavour.make_packet_heap(1, [
                 Item(0x1600, 12345, True),
-                Item(0x5000, 0, False, offset=0)], payload[5 : 12]),
-            self.flavour.make_packet([
-                Item(spead2.HEAP_CNT_ID, 1, True),
-                Item(spead2.PAYLOAD_OFFSET_ID, 32, True),
-                Item(spead2.PAYLOAD_LENGTH_ID, 32, True),
-                Item(spead2.HEAP_LENGTH_ID, 96, True)], payload[32 : 64])
-        ]
+                Item(0x5000, payload, False)],
+                packets=[(5, 12), (32, 64)])
         heaps = self.data_to_heaps(b''.join(packets),
                                    contiguous_only=False,
                                    incomplete_keep_payload_ranges=True,


### PR DESCRIPTION
While there is support for the receiver to consume from multiple concurrent senders, it is always vulnerable to heap loss if one sender is much faster than another, since `max_heaps` limits the number of other heaps that can go by while waiting for one heap to be received. This feature aims to improve that by isolating the age-out mechanism to each producer.

In this first version, the producer is determined by taking the heap cnt modulo the number of substreams, which is a lightweight operation (particularly with libdivide, which is added as a dependency). It would theoretically be possible to place it under user control in future for other schemes.