### PR TITLE
Add Linux "cooked" mode support for pcap dump reader

### DIFF
--- a/include/spead2/common_raw_packet.h
+++ b/include/spead2/common_raw_packet.h
@@ -187,6 +187,26 @@ public:
     ipv4_packet payload_ipv4() const;
 };
 
+/* Wraps a block of contiguous data and provides access to the linux sll
+ * frame header fields.
+ */
+class linux_sll_frame : public packet_buffer
+{
+public:
+    static constexpr std::size_t min_size = 16;
+
+    linux_sll_frame() = default;
+    linux_sll_frame(void *ptr, std::size_t size);
+
+    SPEAD2_DECLARE_FIELD_BE(0, std::uint16_t, packet_type)
+    SPEAD2_DECLARE_FIELD_BE(2, std::uint16_t, arphrd_type)
+    SPEAD2_DECLARE_FIELD_BE(4, std::uint16_t, link_layer_address_length)
+    SPEAD2_DECLARE_FIELD(6, std::uint64_t, link_layer_address,)
+    SPEAD2_DECLARE_FIELD_BE(14, std::uint16_t, protocol_type)
+
+    ipv4_packet payload_ipv4() const;
+};
+
 #undef SPEAD2_DECLARE_FIELD
 
 class packet_type_error : public std::runtime_error
@@ -202,6 +222,15 @@ public:
  * @throws packet_type_error if there are other problems e.g. it is not an IPv4 packet
  */
 packet_buffer udp_from_ethernet(void *ptr, size_t size);
+
+/**
+ * Inspect a Linux SLL encapsulation frame (used when listening to the "any"
+ * device) to extract the UDP4 payload, with sanity checks.
+ *
+ * @throws length_error if any length fields are invalid
+ * @throws packet_type_error if there are other problems e.g. it is not an IPv4 packet
+ */
+packet_buffer udp_from_linux_sll(void *ptr, size_t size);
 
 } // namespace spead2
 

--- a/include/spead2/recv_udp_pcap.h
+++ b/include/spead2/recv_udp_pcap.h
@@ -27,6 +27,7 @@
 #include <cstdint>
 #include <string>
 #include <pcap/pcap.h>
+#include <spead2/common_raw_packet.h>
 #include <spead2/recv_reader.h>
 #include <spead2/recv_udp_base.h>
 #include <spead2/recv_stream.h>
@@ -42,7 +43,9 @@ namespace recv
 class udp_pcap_file_reader : public udp_reader_base
 {
 private:
+    using udp_unpacker = packet_buffer (*)(void *, size_t);
     pcap_t *handle;
+    udp_unpacker udp_from_frame;
 
     void run();
 

--- a/src/recv_udp_pcap.cpp
+++ b/src/recv_udp_pcap.cpp
@@ -22,7 +22,6 @@
 #if SPEAD2_USE_PCAP
 #include <cassert>
 #include <cstdint>
-#include <pcap/dlt.h>
 #include <string>
 #include <spead2/recv_reader.h>
 #include <spead2/recv_stream.h>
@@ -30,6 +29,15 @@
 #include <spead2/recv_udp_pcap.h>
 #include <spead2/common_raw_packet.h>
 #include <spead2/common_logging.h>
+
+// These are defined in pcap/dlt.h for libpcap >= 1.8.0, but in pcap/bfp.h otherwise
+// We define them here to avoid having to guess which file to include
+#ifndef DLT_EN10MB
+#define DLT_EN10MB 1
+#endif
+#ifndef DLT_LINUX_SLL
+#define DLT_LINUX_SLL 113
+#endif
 
 namespace spead2
 {

--- a/src/recv_udp_pcap.cpp
+++ b/src/recv_udp_pcap.cpp
@@ -20,7 +20,9 @@
 
 #include <spead2/common_features.h>
 #if SPEAD2_USE_PCAP
+#include <cassert>
 #include <cstdint>
+#include <pcap/dlt.h>
 #include <string>
 #include <spead2/recv_reader.h>
 #include <spead2/recv_stream.h>
@@ -59,7 +61,7 @@ void udp_pcap_file_reader::run()
                 try
                 {
                     void *bytes = const_cast<void *>((const void *) pkt_data);
-                    packet_buffer payload = udp_from_ethernet(bytes, h->len);
+                    packet_buffer payload = udp_from_frame(bytes, h->len);
                     process_one_packet(state, payload.data(), payload.size(), payload.size());
                 }
                 catch (packet_type_error &e)
@@ -109,6 +111,12 @@ udp_pcap_file_reader::udp_pcap_file_reader(stream &owner, const std::string &fil
         throw error;
     }
     pcap_freecode(&filter);
+    // The link type used to record this file
+    auto linktype = pcap_datalink(handle);
+    assert(linktype != PCAP_ERROR_NOT_ACTIVATED);
+    if (linktype != DLT_EN10MB && linktype != DLT_LINUX_SLL)
+        throw packet_type_error("pcap linktype is neither ethernet nor linux sll");
+    udp_from_frame = (linktype == DLT_EN10MB) ? udp_from_ethernet : udp_from_linux_sll;
 
     // Process the file
     get_io_service().post([this] { run(); });


### PR DESCRIPTION
Today while trying to read a pcap dump from the Tallon correlator for SKA-MID I ran into an issue with the pcap reader not being able to read these files. After some debugging I found out that this was because the data had been captured using the "any" device, as in their experiments they send some data from a server on the loopback interface (i.e, the descriptors) and some other data from the FPGAs.

After learning the difference in the headers, I came up with these two commits that add support for cooked frames to the spead2 pcap reader. The first adds the actual parsing and unit tests, while the second uses this in the pcap reader. Note that the pcap reader didn't previously check that the frames being read were ethernet frames, and thus the problem wasn't obvious at first. A check has been added now to check for the supported types.

For reference, this is the dump: https://drive.google.com/file/d/1FwUGF1d2hzoMO8FFnzsdqo_C1rxTzTq6/view?usp=sharing (requires SKA-related account access)