### PR TITLE
Improvements to tuning docs

### DIFF
--- a/doc/cpp-ibverbs.rst
+++ b/doc/cpp-ibverbs.rst
@@ -21,7 +21,7 @@ PeerDirect
 ----------
 The pointer given to
 :cpp:func:`spead2::send::udp_ibv_config::add_memory_region` is passed to
-:cpp:func:`!ibv_reg_mr`. When using a Mellanox NIC, this can be a pointer that is
+:cpp:func:`!ibv_reg_mr`. When using an NVIDIA NIC, this can be a pointer that is
 handled by PeerDirect, such as a GPU device pointer. This can be used to
 transfer data directly from a GPU to the network without passing though the
 CPU.

--- a/doc/py-ibverbs.rst
+++ b/doc/py-ibverbs.rst
@@ -2,7 +2,7 @@ Support for ibverbs
 ===================
 Receiver performance can be significantly improved by using the Infiniband
 Verbs API instead of the BSD sockets API. This is currently only tested on
-Linux with ConnectX®-5 NICs. It depends on device managed flow steering
+Linux with ConnectX® NICs. It depends on device managed flow steering
 (DMFS).
 
 There are a number of limitations in the current implementation:
@@ -39,7 +39,7 @@ Add the following to :file:`/etc/modprobe.d/mlnx.conf`::
    manual_ for details), but can improve performance when capturing a large
    number of multicast groups.
 
-   .. _manual: http://www.mellanox.com/related-docs/prod_software/Mellanox_EN_for_Linux_User_Manual_v4_3.pdf
+   .. _manual: https://docs.nvidia.com/networking/display/MLNXENv495100/Flow+Steering
 
 ConnectX®-4+, MLNX OFED up to 4.9
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -51,10 +51,20 @@ All other cases
 ^^^^^^^^^^^^^^^
 No system configuration is needed, but the ``CAP_NET_RAW`` capability is
 required. Running as root will achieve this; a full discussion of Linux
-capabilities is beyond the scope of this manual.
+capabilities is beyond the scope of this manual. The :ref:`spead2_net_raw`
+utility can also be used to give users access to this capability without
+exposing full root access.
 For more information, see the `libvma documentation`_.
 
 .. _libvma documentation: https://docs.mellanox.com/category/vma
+
+Multicast loopback
+^^^^^^^^^^^^^^^^^^
+By default, multicast traffic sent using ibverbs can also be received on the
+same port. While convenient, this is a slow path in the NIC, and can limit
+performance. To disable this loopback, write ``1`` to
+:samp:`/sys/class/net/{interface}/settings/force_local_lb_disable` (note that
+the setting does not persist across reboots).
 
 Receiving
 ---------

--- a/doc/tools.rst
+++ b/doc/tools.rst
@@ -45,7 +45,7 @@ mcdump
 ------
 mcdump is a tool similar to tcpdump_, but specialised for high-speed capture of
 UDP traffic using hardware that supports the Infiniband Verbs API. It
-has only been tested on Mellanox ConnectX-3 and ConnectX-5 NICs. Like gulp_, it
+has only been tested on NVIDIA ConnectX NICs. Like gulp_, it
 uses a separate thread for disk I/O and CPU core affinity to achieve reliable
 performance. With a sufficiently fast disk subsystem, it is able to capture
 line rate from a 40Gb/s adapter.


### PR DESCRIPTION
- Add advice on tuning Epyc
- Emphasise importance of ibverbs, and clarify that the Networking
  section only applies to kernel networking.
- Mention chunking receiver in application tuning.
- Update broken link to MLNX EN manual
- Update Mellanox -> NVIDIA in a number of places, and refer to ConnectX
  generically rather than specific iterations.
