### PR TITLE
Bump requirements.txt to more recent versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,9 +15,9 @@ importlib-metadata==4.2.0
     #   pytest
 iniconfig==1.1.1
     # via pytest
-jinja2==3.1.0
+jinja2==3.1.2
     # via -r requirements.in
-llvmlite==0.38.0
+llvmlite==0.38.1
     # via numba
 markupsafe==2.1.1
     # via jinja2
@@ -25,9 +25,9 @@ mccabe==0.6.1
     # via flake8
 netifaces==0.11.0
     # via -r requirements.in
-numba==0.55.1
+numba==0.55.2
     # via -r requirements.in
-numpy==1.21.5
+numpy==1.21.6
     # via
     #   -r requirements.in
     #   numba
@@ -46,14 +46,14 @@ pycparser==2.21
     # via -r requirements.in
 pyflakes==2.4.0
     # via flake8
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via packaging
-pytest==7.1.1
+pytest==7.1.2
     # via
     #   -r requirements.in
     #   pytest-asyncio
     #   pytest-timeout
-pytest-asyncio==0.18.2
+pytest-asyncio==0.18.3
     # via -r requirements.in
 pytest-timeout==2.1.0
     # via -r requirements.in
@@ -61,11 +61,11 @@ scipy==1.7.3
     # via -r requirements.in
 tomli==2.0.1
     # via pytest
-typing-extensions==4.1.1
+typing-extensions==4.3.0
     # via
     #   importlib-metadata
     #   pytest-asyncio
-zipp==3.7.0
+zipp==3.8.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
In some cases these aren't the latest released versions because I'm
still supporting Python 3.7.