### PR TITLE
Move most of setup.py into setup.cfg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,7 @@ jobs:
       - run: ./bootstrap.sh
       - name: Prepare Python build for coverage
         run: |
-          echo '[build_ext]' > setup.cfg
+          echo '[build_ext]' >> setup.cfg
           echo 'coverage = yes' >> setup.cfg
       - run: pip install -v .
       - name: Run Python tests

--- a/manylinux/before_all.sh
+++ b/manylinux/before_all.sh
@@ -36,7 +36,7 @@ cp /usr/share/aclocal/pkg.m4 /usr/local/share/aclocal/
 wget https://raw.githubusercontent.com/ridiculousfish/libdivide/5.0/libdivide.h -O /usr/local/include/libdivide.h
 
 # Prepare for split debug symbols for the wheels
-cat <<EOF > "$package/setup.cfg"
+cat <<EOF >> "$package/setup.cfg"
 [build_ext]
 split_debug = /output
 EOF

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,60 @@
+# Copyright 2015, 2017, 2019-2022 National Research Foundation (SARAO)
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+[metadata]
+name = spead2
+author = Bruce Merry
+author_email = bmerry@sarao.ac.za
+url = https://github.com/ska-sa/spead2
+long_description = file: README.rst
+version = attr: spead2._version.__version__
+description = High-performance SPEAD implementation
+license = LGPLv3+
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Framework :: AsyncIO
+    Intended Audience :: Developers
+    License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)
+    Operating System :: POSIX
+    Programming Language :: Python :: 3
+    Topic :: Software Development :: Libraries
+    Topic :: System :: Networking
+
+[options]
+package_dir =
+    = src
+packages = find:
+python_requires = >=3.7
+install_requires =
+    numpy>=1.9.2
+tests_require =
+    netifaces
+    numba
+    pytest
+    pytest-asyncio
+    pytest-timeout
+    scipy
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+console_scripts =
+    spead2_send.py = spead2.tools.send_asyncio:main
+    spead2_recv.py = spead2.tools.recv_asyncio:main
+    spead2_bench.py = spead2.tools.bench_asyncio:main
+
+[options.package_data]
+* = py.typed, *.pyi

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import os
 import os.path
 import subprocess
 
-from setuptools import setup, find_packages, Extension
+from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 
 import pybind11

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2015, 2017, 2019-2020 National Research Foundation (SARAO)
+# Copyright 2015, 2017, 2019-2022 National Research Foundation (SARAO)
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -25,16 +25,6 @@ from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
 
 import pybind11
-
-
-def find_version():
-    # Cannot simply import it, since that tries to import spead2 as well, which
-    # isn't built yet.
-    globals_ = {}
-    with open(os.path.join(os.path.dirname(__file__), 'src', 'spead2', '_version.py')) as f:
-        code = f.read()
-    exec(code, globals_)
-    return globals_['__version__']
 
 
 class BuildExt(build_ext):
@@ -136,50 +126,8 @@ if not rtd:
 else:
     extensions = []
 
-with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme_file:
-    readme = readme_file.read()
-
 setup(
-    author='Bruce Merry',
-    author_email='bmerry@sarao.ac.za',
-    name='spead2',
-    version=find_version(),
-    description='High-performance SPEAD implementation',
-    long_description=readme,
-    url='https://github.com/ska-sa/spead2',
-    license='LGPLv3+',
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Framework :: AsyncIO',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
-        'Operating System :: POSIX',
-        'Programming Language :: Python :: 3',
-        'Topic :: Software Development :: Libraries',
-        'Topic :: System :: Networking'],
     ext_package='spead2',
     ext_modules=extensions,
-    cmdclass={'build_ext': BuildExt},
-    install_requires=[
-        'numpy>=1.9.2'
-    ],
-    tests_require=[
-        'netifaces',
-        'numba',
-        'pytest',
-        'pytest-asyncio',
-        'pytest-timeout',
-        'scipy'
-    ],
-    python_requires='>=3.7',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    package_data={'': ['py.typed', '*.pyi']},
-    entry_points={
-        'console_scripts': [
-            'spead2_send.py = spead2.tools.send_asyncio:main',
-            'spead2_recv.py = spead2.tools.recv_asyncio:main',
-            'spead2_bench.py = spead2.tools.bench_asyncio:main'
-        ]
-    }
+    cmdclass={'build_ext': BuildExt}
 )


### PR DESCRIPTION
This is a bit of maintenance which will allow other tools (hopefully
including dependabot) to access metadata.

It also makes the code a bit simpler, because we can use the `file:` and
`attr:` magic in setup.cfg.