### PR TITLE
Use autodoc's mocking mechanism instead of our own

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,6 +25,8 @@ sys.path.insert(0, os.path.abspath('..'))
 rtd = os.environ.get('READTHEDOCS') == 'True'
 if rtd:
     subprocess.check_call(['doxygen'])
+    # ReadTheDocs can't build the extension (no Boost), so we have to mock it
+    # See http://docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
     autodoc_mock_imports = ['spead2._spead2', 'spead2._spead2.send', 'spead2._spead2.recv']
 
 # -- Project information -----------------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ if rtd:
     subprocess.check_call(['doxygen'])
     # ReadTheDocs can't build the extension (no Boost), so we have to mock it
     # See http://docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
-    autodoc_mock_imports = ['spead2._spead2', 'spead2._spead2.send', 'spead2._spead2.recv']
+    autodoc_mock_imports = ['spead2._spead2']
 
 # -- Project information -----------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,14 +25,7 @@ sys.path.insert(0, os.path.abspath('..'))
 rtd = os.environ.get('READTHEDOCS') == 'True'
 if rtd:
     subprocess.check_call(['doxygen'])
-    # ReadTheDocs can't build the extension (no Boost), so we have to mock it
-    # See http://docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
-    import unittest.mock
-    MOCK_MODULES = ['spead2._spead2', 'spead2._spead2.send', 'spead2._spead2.recv']
-    sys.modules.update((mod_name, unittest.mock.Mock()) for mod_name in MOCK_MODULES)
-    # Mocking certain classes causes subclasses not to be documented properly
-    sys.modules['spead2._spead2.send'].UdpStreamAsyncio = object
-    sys.modules['spead2._spead2.send'].UdpIbvStreamAsyncio = object
+    autodoc_mock_imports = ['spead2._spead2', 'spead2._spead2.send', 'spead2._spead2.recv']
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
The latter prevented asyncio.TcpStream.connect's documentation from being generated, which was confusing. Using autodoc's own mocking mechanism seems to fix this issue, and hopefully prevent future ones.

See https://spead2.readthedocs.io/en/latest/py-send.html#id2 for the current missing documentation.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>