### PR TITLE
Support placing extra data into chunks

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 .. rubric:: Development version
 
 - The chunking receiver is no longer experimental.
+- The place callback for the chunking receiver can now provide extra data to be
+  written to the chunk.
 
 .. rubric:: 3.10.0
 

--- a/doc/py-recv-chunk.rst
+++ b/doc/py-recv-chunk.rst
@@ -65,6 +65,13 @@ Reference
    as it is contiguous and writable. It can also be set to ``None`` to clear
    it.
 
+   .. py:attribute:: extra
+
+   Data storage for extra data to be written by the place callback. This
+   can be set to any object that supports the Python buffer protocol, as long
+   as it is contiguous and writable. It can also be set to ``None`` to clear
+   it.
+
    .. py:attribute:: chunk_id
 
    The chunk ID determined by the placement function.
@@ -89,6 +96,9 @@ Reference
      heaps from a previous chunk will be accepted.
    :param tuple place:
      See :ref:`place-callback`.
+   :param int max_heap_extra:
+     The maximum amount of data a placement function may write to
+     :cpp:member:`spead2::recv::chunk_place_data::extra`.
    :raises ValueError: if `max_chunks` is zero.
 
    .. py:method:: enable_packet_presence(payload_size: int)

--- a/doc/recv-chunk.rst
+++ b/doc/recv-chunk.rst
@@ -82,6 +82,29 @@ When using this feature one may wish to enable the ``allow_out_of_order`` flag
 when configuring the stream, so that the loss of a packet in the middle of a
 heap does not prevent the following packets from being processed.
 
+.. _chunk-extra:
+
+Extra data
+----------
+In some cases the place callback may wish to extract additional data from
+each heap (such as immediate items) and make it available as part of the
+chunk. To do this:
+
+1. Set the ``extra`` member of each chunk to a buffer to hold this data.
+2. When configuring the stream, specify the maximum amount of data that
+   may be written here per heap.
+3. As part of the place callback, write data through the ``extra`` pointer,
+   and set the ``extra_offset`` and ``extra_size`` fields to indicate how
+   much data to copy to the chunk and at which byte offset within the
+   ``extra`` field. The ``extra_size`` field defaults to zero, so if you
+   do not have any extra data to emit these fields need not be explicitly
+   set.
+
+At present it is only possible to write a contiguous piece of data per heap.
+
+The data is transferred to the chunk even if the heap is incomplete (and hence
+not marked in the ``present`` array).
+
 Ringbuffer convenience API
 --------------------------
 A subclass is provided that takes care of the allocation and ready callbacks

--- a/src/py_recv.cpp
+++ b/src/py_recv.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2017, 2020-2021 National Research Foundation (SARAO)
+/* Copyright 2015, 2017, 2020-2022 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -849,12 +849,15 @@ py::module register_module(py::module &parent)
         .def("disable_packet_presence", SPEAD2_PTMF(chunk_stream_config, disable_packet_presence))
         .def_property_readonly("packet_presence_payload_size",
                                SPEAD2_PTMF(chunk_stream_config, get_packet_presence_payload_size))
+        .def_property("max_heap_extra",
+                      SPEAD2_PTMF(chunk_stream_config, get_max_heap_extra),
+                      SPEAD2_PTMF(chunk_stream_config, set_max_heap_extra))
         .def_readonly_static("DEFAULT_MAX_CHUNKS", &chunk_stream_config::default_max_chunks);
     py::class_<chunk>(m, "Chunk")
         .def(py::init(&data_class_constructor<chunk>))
         .def_readwrite("chunk_id", &chunk::chunk_id)
         .def_readwrite("stream_id", &chunk::stream_id)
-        // Can't use def_readwrite for present and data because they're
+        // Can't use def_readwrite for present, data, extra because they're
         // non-copyable types
         .def_property(
             "present",
@@ -874,7 +877,11 @@ py::module register_module(py::module &parent)
         .def_property(
             "data",
             [](const chunk &c) -> const memory_allocator::pointer & { return c.data; },
-            [](chunk &c, memory_allocator::pointer &&value) { c.data = std::move(value); });
+            [](chunk &c, memory_allocator::pointer &&value) { c.data = std::move(value); })
+        .def_property(
+            "extra",
+            [](const chunk &c) -> const memory_allocator::pointer & { return c.extra; },
+            [](chunk &c, memory_allocator::pointer &&value) { c.extra = std::move(value); });
     py::class_<chunk_ring_stream_wrapper, stream>(m, "ChunkRingStream")
         .def(py::init<std::shared_ptr<thread_pool_wrapper>,
                       const stream_config &,

--- a/src/recv_chunk_stream.cpp
+++ b/src/recv_chunk_stream.cpp
@@ -335,6 +335,12 @@ chunk_stream_state::allocate(std::size_t size, const packet_header &packet)
             metadata.heap_index = place_data->heap_index;
             metadata.heap_offset = place_data->heap_offset;
             metadata.chunk_ptr = &c;
+            if (place_data->extra_size > 0)
+            {
+                assert(place_data->extra_size <= chunk_config.get_max_heap_extra());
+                assert(c.extra);
+                std::memcpy(c.extra.get() + place_data->extra_offset, place_data->extra, place_data->extra_size);
+            }
             return out;
         }
         else

--- a/src/spead2/recv/__init__.pyi
+++ b/src/spead2/recv/__init__.pyi
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 National Research Foundation (SARAO)
+# Copyright 2019-2022 National Research Foundation (SARAO)
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -210,6 +210,7 @@ class ChunkStreamConfig:
     items: List[int]
     max_chunks: int
     place: Optional[tuple]
+    max_heap_extra: int
     def enable_packet_presence(self, payload_size: int) -> None: ...
     def disable_packet_presence(self) -> None: ...
     @property
@@ -217,17 +218,18 @@ class ChunkStreamConfig:
 
     def __init__(
         self, *, items: List[int] = ..., max_chunks: int = ...,
-        place: Optional[tuple] = ...) -> None: ...
+        place: Optional[tuple] = ..., max_heap_extra: int = ...) -> None: ...
 
 class Chunk:
     chunk_id: int
     stream_id: int
     present: object  # optional buffer protocol
     data: object     # optional buffer protocol
+    extra: object    # optional buffer protocol
 
     def __init__(
         self, *, chunk_id: int = ..., stream_id: int = ...,
-        present: object = ..., data: object = ...) -> None: ...
+        present: object = ..., data: object = ..., extra: object = ...) -> None: ...
 
 # Dummy base class because the async ChunkRingbuffer.get has a different
 # signature to the synchronous version.

--- a/src/spead2/recv/numba.py
+++ b/src/spead2/recv/numba.py
@@ -1,4 +1,4 @@
-# Copyright 2021 National Research Foundation (SARAO)
+# Copyright 2021-2022 National Research Foundation (SARAO)
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -18,15 +18,23 @@
 from numba import types
 
 
-# numba.types doesn't have a size_t, so assume it is the same as uintptr_t
+try:
+    _size_t = types.size_t
+except AttributeError:
+    # Older versions of numba.types doesn't have a size_t, so assume it is the same as uintptr_t
+    _size_t = types.uintp
+
 chunk_place_data = types.Record.make_c_struct([
     ('packet', types.intp),  # uint8_t *
-    ('packet_size', types.uintp),
+    ('packet_size', _size_t),
     ('items', types.intp),   # s_item_pointer_t *
     ('chunk_id', types.int64),
-    ('heap_index', types.uintp),
-    ('heap_offset', types.uintp),
-    ('batch_stats', types.intp)  # uint64_t *
+    ('heap_index', _size_t),
+    ('heap_offset', _size_t),
+    ('batch_stats', types.intp),  # uint64_t *
+    ('extra', types.intp),  # uint8_t *
+    ('extra_offset', _size_t),
+    ('extra_size', _size_t)
 ])
 """Numba record type representing the C structure used in the chunk placement callback.
 


### PR DESCRIPTION
Allow the place callback to emit a block of data to be placed into the chunk at a particular offset. This makes it practical to capture immediate items from the heaps.