### PR TITLE
Update unit tests where async tasks were unhandled

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+.. rubric:: Development version
+
+- Update test_send_asyncio.py's :py:meth:`test_async_flush` and
+  :py:meth:`test_async_flush_fail` to keep handles on its async Tasks.
+
 .. rubric:: 3.11.1
 
 - Fix a packaging issue that meant automake and similar tools were required to

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,8 +3,8 @@ Changelog
 
 .. rubric:: Development version
 
-- Update test_send_asyncio.py's :py:meth:`test_async_flush` and
-  :py:meth:`test_async_flush_fail` to keep handles on its async Tasks.
+- Update :program:`test_send_asyncio.py`'s ``test_async_flush`` and
+  ``test_async_flush_fail`` to keep handles on its async Tasks.
 
 .. rubric:: 3.11.1
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,8 +3,8 @@ Changelog
 
 .. rubric:: Development version
 
-- Update :program:`test_send_asyncio.py`'s ``test_async_flush`` and
-  ``test_async_flush_fail`` to keep handles on its async Tasks.
+- Update :meth:`!test_async_flush` and :meth:`!test_async_flush_fail` to keep
+  handles to async tasks, to prevent them being garbage collected too early.
 
 .. rubric:: 3.11.1
 

--- a/tests/test_send_asyncio.py
+++ b/tests/test_send_asyncio.py
@@ -44,18 +44,23 @@ class TestUdpStream:
         assert self.stream._active == 0
 
     async def test_async_flush(self):
+        send_heap_futures = []
         for i in range(3):
-            asyncio.ensure_future(self.stream.async_send_heap(self.heap))
+            send_heap_futures.append(asyncio.ensure_future(self.stream.async_send_heap(self.heap)))
         await self._test_async_flush()
+        await asyncio.gather(*send_heap_futures)
 
     async def test_async_flush_fail(self):
         """Test async_flush in the case that the last heap sent failed.
 
         This is arranged by filling up the queue slots first.
         """
+        send_heap_futures = []
         for i in range(5):
-            asyncio.ensure_future(self.stream.async_send_heap(self.heap))
+            send_heap_futures.append(asyncio.ensure_future(self.stream.async_send_heap(self.heap)))
         await self._test_async_flush()
+        with pytest.raises(BlockingIOError):
+            await asyncio.gather(*send_heap_futures)
 
     async def test_send_error(self):
         """An error in sending must be reported through the future."""


### PR DESCRIPTION
Just the two unit tests, actually.

Contributes to: NGC-899.