### PR TITLE
Fix a shutdown hang

### DIFF
--- a/.ci/py-tests.sh
+++ b/.ci/py-tests.sh
@@ -3,7 +3,7 @@ set -e
 
 # -ra summarises the reasons for skipping or failing tests
 pytest -v -ra
-for test in test_logging_shutdown test_running_thread_pool test_running_stream; do
+for test in test_logging_shutdown test_running_thread_pool test_running_stream test_running_chunk_stream_group; do
     echo "Running shutdown test $test"
     python -c "import tests.shutdown; tests.shutdown.$test()"
 done

--- a/include/spead2/recv_chunk_stream_group.h
+++ b/include/spead2/recv_chunk_stream_group.h
@@ -403,9 +403,9 @@ T &chunk_stream_group::emplace_back(Args&&... args)
     {
         throw std::runtime_error("Cannot add a stream after group has started receiving data");
     }
-    std::unique_ptr<chunk_stream_group_member> stream(new T(
+    std::unique_ptr<T> stream(new T(
         *this, streams.size(), std::forward<Args>(args)...));
-    chunk_stream_group_member &ret = *stream;
+    T &ret = *stream;
     streams.push_back(std::move(stream));
     head_chunks.push_back(0);
     stream_added(ret);

--- a/src/py_recv.cpp
+++ b/src/py_recv.cpp
@@ -494,8 +494,7 @@ using chunk_stream_ring_group_orig = chunk_stream_ring_group<chunk_ringbuffer, c
 
 EXIT_STOPPER_WRAPPER(chunk_ring_stream_wrapper, chunk_ring_stream_orig);
 EXIT_STOPPER_WRAPPER(chunk_stream_ring_group_wrapper, chunk_stream_ring_group_orig);
-// We don't need to wrap chunk_stream_group_member, because we've wrapped
-// chunk_stream_ring_group and its stop will stop the member streams.
+EXIT_STOPPER_WRAPPER(chunk_stream_group_member_wrapper, chunk_stream_group_member);
 
 #undef EXIT_STOPPER_WRAPPER
 
@@ -1022,7 +1021,7 @@ py::module register_module(py::module &parent)
                std::shared_ptr<thread_pool_wrapper> thread_pool,
                const stream_config &config,
                const chunk_stream_config &chunk_stream_config) -> chunk_stream_group_member & {
-                return group.emplace_back(std::move(thread_pool), config, chunk_stream_config);
+                return group.emplace_back<chunk_stream_group_member_wrapper>(std::move(thread_pool), config, chunk_stream_config);
             },
             "thread_pool"_a, "config"_a, "chunk_stream_config"_a,
             py::return_value_policy::reference_internal

--- a/tests/shutdown.py
+++ b/tests/shutdown.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 National Research Foundation (SARAO)
+# Copyright 2017-2018, 2023 National Research Foundation (SARAO)
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -15,16 +15,23 @@
 
 """Tests for shutdown ordering.
 
-These cannot be run through nosetests because they deal with interpreter
+These cannot be run through pytest because they deal with interpreter
 shutdown.
 """
 
 import logging
 
+import numba
+import numpy as np
+import scipy
+from numba import types
+
 import spead2
 import spead2.recv
 import spead2.send
 import spead2._spead2
+from spead2.numba import intp_to_voidptr
+from spead2.recv.numba import chunk_place_data
 
 
 def test_logging_shutdown():
@@ -55,3 +62,53 @@ def test_running_stream():
     heap = ig.get_heap()
     for i in range(5):
         sender.send_heap(heap)
+
+
+def test_running_chunk_stream_group():
+    @numba.cfunc(types.void(types.CPointer(chunk_place_data), types.uintp), nopython=True)
+    def place(data_ptr, data_size):
+        data = numba.carray(data_ptr, 1)
+        items = numba.carray(intp_to_voidptr(data[0].items), 2, dtype=np.int64)
+        heap_cnt = items[0]
+        payload_size = items[1]
+        if payload_size == 1024:
+            data[0].chunk_id = heap_cnt
+            data[0].heap_index = 0
+            data[0].heap_offset = 0
+
+    global group
+    group = spead2.recv.ChunkStreamRingGroup(
+        spead2.recv.ChunkStreamGroupConfig(
+            max_chunks=2,
+            eviction_mode=spead2.recv.ChunkStreamGroupConfig.EvictionMode.LOSSLESS
+        ),
+        spead2.recv.ChunkRingbuffer(4),
+        spead2.recv.ChunkRingbuffer(4)
+    )
+    for _ in range(group.free_ringbuffer.maxsize):
+        chunk = spead2.recv.Chunk(data=np.zeros(1024, np.uint8), present=np.zeros(1, np.uint8))
+        group.add_free_chunk(chunk)
+    place_llc = scipy.LowLevelCallable(place.ctypes, signature='void (void *, size_t)')
+    for _ in range(2):
+        group.emplace_back(
+            spead2.ThreadPool(),
+            spead2.recv.StreamConfig(),
+            spead2.recv.ChunkStreamConfig(
+                items=[spead2.HEAP_CNT_ID, spead2.HEAP_LENGTH_ID],
+                max_chunks=2,
+                place=place_llc
+            )
+        )
+    queues = [spead2.InprocQueue() for _ in group]
+    for queue, stream in zip(queues, group):
+        stream.add_inproc_reader(queue)
+
+    # Send 4 chunks of data to the first stream. This will cause it to block
+    # while it waits for the second stream to progress.
+    send_stream = spead2.send.InprocStream(spead2.ThreadPool(), queues)
+    ig = spead2.send.ItemGroup()
+    ig.add_item(0x1000, "payload", "payload", shape=(1024,), dtype=np.uint8)
+    ig["payload"].value = np.ones(1024, np.uint8)
+    heap = ig.get_heap(descriptors="none", data="all")
+    for _ in range(4):
+        send_stream.send_heap(heap, substream_index=0)


### PR DESCRIPTION
If the process exits without explicitly stopping anything, it's possible deadlock if the threadpools used for the streams in a group were created after the group. This happens because `atexit` stops the threadpools before it stops the group.

Fix it by giving the exit_stopper treatment to
chunk_stream_group_member. Since the member is necessarily constructed after the thread pool it uses, this ensures that the member (and hence the whole group) is stopped before the thread pool.