### PR TITLE
Some fixes for spead2_bench.py

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -20,6 +20,8 @@ Changelog
   the parameter name for `chunk_stream_config` was incorrect.
 - Fix universal binary builds on MacOS (this was preventing Python 3.11 builds
   from succeeding).
+- Fix :program:`spead2_bench.py`, which has failed to run at all for some time
+  (possibly since 3.0).
 - Python 3.8 is now the minimum version.
 
 .. rubric:: 3.11.1

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2017, 2019-2020 National Research Foundation (SARAO)
+/* Copyright 2015, 2017, 2019-2020, 2023 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -422,7 +422,7 @@ static void main_master(int argc, const char **argv)
     if (result.first)
     {
         if (!opts.quiet)
-            std::cout << "Limited by send spead\n";
+            std::cout << "Limited by send speed\n";
         best_actual = result.second;
     }
     else


### PR DESCRIPTION
- Serialize and deserialize enums when sent between master and agent (this failure means it's probably crashed ever since 3.0).
- Show a helpful error when run without arguments.
- Fix spelling of "speed".