### PR TITLE
Wheel build improvements

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -20,6 +20,11 @@ Changelog
   the parameter name for `chunk_stream_config` was incorrect.
 - Fix universal binary builds on MacOS (this was preventing Python 3.11 builds
   from succeeding).
+- Avoid including Boost dynamic symbols in the Python module (helps reduce
+  binary size).
+- Strip static symbols out of the Python wheels (reduces size).
+- Build Python wheels with link-time optimisation (small performance
+  improvement).
 - Python 3.8 is now the minimum version.
 
 .. rubric:: 3.11.1

--- a/manylinux/before_all.sh
+++ b/manylinux/before_all.sh
@@ -13,6 +13,10 @@ yum install -y \
 
 # Workaround for https://github.com/pypa/manylinux/issues/1203
 unset SSL_CERT_FILE
+# The config file sets CFLAGS/LDFLAGS for the actual build, but these break
+# building rdma-core
+unset CFLAGS
+unset LDFLAGS
 
 # Install boost
 wget --progress=dot:mega https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.bz2 -O /tmp/boost_1_81_0.tar.bz2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,5 @@ archs = ["x86_64"]
 
 [tool.cibuildwheel.linux.environment]
 CC = "ccache gcc"
+CFLAGS = "-flto"
+LDFLAGS = "-flto"

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,9 @@ if not rtd:
             depends=glob.glob('include/spead2/*.h'),
             language='c++',
             include_dirs=['include', pybind11.get_include()],
+            # We don't need to pass boost::asio objects across shared library
+            # boundaries. This macro makes -fvisibility=hidden do its job.
+            define_macros=[('BOOST_ASIO_DISABLE_VISIBILITY', None)],
             extra_compile_args=['-std=c++11', '-g0', '-fvisibility=hidden'])
     ]
 else:

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ class BuildExt(build_ext):
             basename = os.path.basename(ext_path)
             debug_path = os.path.join(self.split_debug, basename + '.debug')
             self.spawn(['objcopy', '--only-keep-debug', '--', ext_path, debug_path])
-            self.spawn(['strip', '--strip-debug', '--', ext_path])
+            self.spawn(['strip', '--strip-debug', '--strip-unneeded', '--', ext_path])
             old_cwd = os.getcwd()
             # See the documentation for --add-gnu-debuglink for why it needs to be
             # run from the directory containing the file.

--- a/setup.py
+++ b/setup.py
@@ -121,9 +121,14 @@ if not rtd:
             depends=glob.glob('include/spead2/*.h'),
             language='c++',
             include_dirs=['include', pybind11.get_include()],
-            # We don't need to pass boost::asio objects across shared library
-            # boundaries. This macro makes -fvisibility=hidden do its job.
-            define_macros=[('BOOST_ASIO_DISABLE_VISIBILITY', None)],
+            # We don't need to pass boost objects across shared library
+            # boundaries. These macros makes -fvisibility=hidden do its job.
+            # The first is asio-specific, while the latter is only used in
+            # Boost 1.81+.
+            define_macros=[
+                ('BOOST_ASIO_DISABLE_VISIBILITY', None),
+                ('BOOST_DISABLE_EXPLICIT_SYMBOL_VISIBILITY', None)
+            ],
             extra_compile_args=['-std=c++11', '-g0', '-fvisibility=hidden'])
     ]
 else:


### PR DESCRIPTION
- Strip static symbols
- Stop boost inserting dynamic symbols, which aren't needed as we're not passing boost objects (or exceptions) across the interface boundary)
- Use link-time optimisation