### PR TITLE
Remove wheel from build-system.requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "pybind11==2.10.3", "setuptools_scm==7.1.0"]
+requires = ["setuptools", "pybind11==2.10.3", "setuptools_scm==7.1.0"]
 
 [tool.cibuildwheel]
 build-frontend = "build"


### PR DESCRIPTION
See https://setuptools.pypa.io/en/latest/userguide/quickstart.html, which says

> Historically this documentation has unnecessarily listed wheel in the
> requires list, and many projects still do that. This is not recommended.
> The backend automatically adds wheel dependency when it is required, and
> listing it explicitly causes it to be unnecessarily required for source
> distribution builds. You should only include wheel in requires if you
> need to explicitly access it during build time (e.g. if your project
> needs a setup.py script that imports wheel).