### PR TITLE
Have cibuildwheel test the wheels it builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ manylinux-i686-image="manylinux2014"
 manylinux-aarch64-image="manylinux2014"
 build = ["cp38-manylinux*", "cp39-manylinux*", "cp310-manylinux*", "cp311-manylinux*", "cp312-manylinux*"]
 
+before-test = "pip install -r {package}/requirements.txt -r {package}/requirements-3.12.txt"
+test-command = "pytest -v {package}/tests"
+
 [tool.cibuildwheel.linux]
 archs = ["x86_64"]
 

--- a/tests/test_recv.py
+++ b/tests/test_recv.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import platform
 import socket
 import struct
@@ -1231,7 +1232,8 @@ class TestUdpReader:
             receiver.add_udp_reader(100000)
 
     @pytest.mark.skipif(
-        sys.platform == "darwin", reason="Test does not work with macos on Github Actions"
+        sys.platform == "darwin" or os.environ.get("CIBUILDWHEEL") == "1",
+        reason="Test does not work with macos on Github Actions or under cibuildwheel",
     )
     def test_illegal_udp_port(self):
         receiver = recv.Stream(spead2.ThreadPool())


### PR DESCRIPTION
This improves test coverage in a few ways:
- it tests against all the Python versions for which wheels are built (the rest of the unit tests only cover min and max versions)
- it tests the wheels rather than the source code
- once other architectures are added, those will get tests too