### PR TITLE
Set an initial value for send::stream::need_wakeup

### DIFF
--- a/include/spead2/send_stream.h
+++ b/include/spead2/send_stream.h
@@ -211,7 +211,7 @@ private:
     /// Heap cnt for the next heap to send
     item_pointer_t next_cnt = 1;
     /// If true, the writer wants to be woken up when a new heap is added
-    bool need_wakeup;
+    bool need_wakeup = false;
 
     /* Data that's only mostly written by the writer (apart from flush()), and
      * may be read by the stream.


### PR DESCRIPTION
Valgrind was showing that the TCP test was using this before it got initialised by anything else. That might (or might not) be related to a segfault in Github Actions:
https://github.com/ska-sa/spead2/actions/runs/5890668734/job/15976547907