### PR TITLE
Move mypy configuration into pyproject.toml

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,0 @@
-[mypy]
-ignore_missing_imports = 1
-files = src/spead2, examples, tests
-python_version = 3.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,8 @@ py_version = 38
 [tool.black]
 line-length = 100
 target-versions = ["py38", "py39", "py310", "py311", "py312"]
+
+[tool.mypy]
+ignore_missing_imports = true
+files = ["src/spead2", "examples", "tests"]
+python_version = "3.8"


### PR DESCRIPTION
This keeps all the static checkers (isort, black, mypy) together, except for flake8 which refuses to use pyproject.