### PR TITLE
Add some more sleeps to the tests

### DIFF
--- a/tests/test_recv.py
+++ b/tests/test_recv.py
@@ -1084,6 +1084,9 @@ class TestStream:
         heaps = list(receiver)
         assert len(heaps) == 1
 
+        # Stats are updated asynchronously, so if we ask for them immediately
+        # they might not reflect the heap just received.
+        time.sleep(0.01)
         stats = receiver.stats
         assert stats.heaps == 1
         assert stats.packets == 2

--- a/tests/test_recv_chunk_stream_group.py
+++ b/tests/test_recv_chunk_stream_group.py
@@ -268,7 +268,7 @@ class TestChunkStreamRingGroup:
             heap = ig.get_heap(data="all", descriptors="none")
             send_stream.send_heap(heap, substream_index=i % STREAMS)
             if lossy:
-                time.sleep(0.001)
+                time.sleep(0.003)
 
     def _verify(self, group, data, expected_present, chunk_id_bias=0):
         expected_present = expected_present.reshape(-1, HEAPS_PER_CHUNK)


### PR DESCRIPTION
A few of the tests are fundamentally non-deterministic. Add/increase sleeps to reduce the chance of tests failing. Particularly useful now that cibuildwheel is also running tests.