### PR TITLE
Build all the wheels in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,5 +213,20 @@ jobs:
           path: ./wheelhouse/*.whl
       - uses: actions/upload-artifact@v3
         with:
-          name: debug_symbols
+          name: debug_symbols_uncompressed
           path: ./wheelhouse/*.debug
+
+  compress-debug:
+    needs: [cibuildwheel]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: debug_symbols_uncompressed
+      - name: Compress debug symbols
+        run: tar -Jcvf "spead2-$(sed 's/.*"\(.*\)"/\1/' src/spead2/_version.py)-debug.tar.xz" _spead*.debug
+      - uses: actions/upload-artifact@v3
+        with:
+          name: debug_symbols
+          path: spead2-*-debug.tar.xz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,19 +192,26 @@ jobs:
   cibuildwheel:
     needs: [test-cxx, test-python, coverage]
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, aarch64]
+        python: [cp38, cp39, cp310, cp311, cp312]
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64
+        if: matrix.arch != 'x86_64'
       - uses: pypa/cibuildwheel@v2.15.0
+        env:
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BUILD: ${{ matrix.python }}-manylinux*
       - uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: ./wheelhouse/*.whl
-      - name: Tar debug symbols
-        run: cd wheelhouse && tar -Jcvf "spead2-$(sed 's/.*"\(.*\)"/\1/' ../src/spead2/_version.py)-debug.tar.xz" _spead2*.debug
       - uses: actions/upload-artifact@v3
         with:
           name: debug_symbols
-          path: ./wheelhouse/spead2-*-debug.tar.xz
+          path: ./wheelhouse/*.debug


### PR DESCRIPTION
This speeds up the latency process, even though it increases the total work (because before_all.sh now runs for every wheel, instead of once per architecture).

A new stage is added at the end to fetch the debug symbols produced for each wheel and put them into a single compressed tarball. This gets much better compression than the zipfile that Github produces for the artifact (I'm guessing because the individual files have a lot of commonality, and a .tar.xz is a compressed archive of files while .zip is an archive of compressed files.