### PR TITLE
meson: simplify cuda_dep

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -55,7 +55,9 @@ boost_unit_test_framework_dep = dependency(
   disabler : true
 )
 if add_languages('cuda', required : get_option('cuda'), native : false)
-  cuda_dep = dependency('cuda', required : get_option('cuda'), disabler : true)
+  # Empty but found dependency; the compiler takes care of CUDA so we don't
+  # need to explicitly link to anything.
+  cuda_dep = declare_dependency()
 else
   cuda_dep = disabler()
 endif


### PR DESCRIPTION
Using `dependency('cuda')` is only necessary if linking CUDA into a
project that isn't using nvcc, or if using extra libs like cublas.
Neither applies here, so I've replaced cuda_dep with an empty
dependency. Dependencies are still helpful because one can use a
disabler if CUDA is not found or is disabled by user options.
