### PR TITLE
Clear some objects at the end of tests

### DIFF
--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -728,10 +728,13 @@ class TestPassthroughInproc(BaseTestPassthroughSubstreams):
         )
         for queue in self._queues:
             queue.stop()
-        self._queues.clear()  # Allow them to be garbage-collected
         return ret
 
     def test_queues(self):
         queues = [spead2.InprocQueue() for i in range(2)]
         stream = spead2.send.InprocStream(spead2.ThreadPool(), queues)
         assert stream.queues == queues
+
+    def teardown_method(self):
+        # Workaround for https://github.com/pytest-dev/pytest/issues/11374
+        getattr(self, "_queues", []).clear()

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -728,6 +728,7 @@ class TestPassthroughInproc(BaseTestPassthroughSubstreams):
         )
         for queue in self._queues:
             queue.stop()
+        self._queues.clear()  # Allow them to be garbage-collected
         return ret
 
     def test_queues(self):

--- a/tests/test_passthrough_asyncio.py
+++ b/tests/test_passthrough_asyncio.py
@@ -204,5 +204,8 @@ class TestPassthroughInproc(BaseTestPassthroughSubstreamsAsync):
         )
         for queue in self._queues:
             queue.stop()
-        self._queues.clear()  # Allow them to be garbage-collected
         return ret
+
+    def teardown_method(self):
+        # Workaround for https://github.com/pytest-dev/pytest/issues/11374
+        getattr(self, "_queues", []).clear()

--- a/tests/test_passthrough_asyncio.py
+++ b/tests/test_passthrough_asyncio.py
@@ -204,4 +204,5 @@ class TestPassthroughInproc(BaseTestPassthroughSubstreamsAsync):
         )
         for queue in self._queues:
             queue.stop()
+        self._queues.clear()  # Allow them to be garbage-collected
         return ret

--- a/tests/test_recv.py
+++ b/tests/test_recv.py
@@ -1246,7 +1246,8 @@ class TestTcpReader:
 
     def teardown_method(self):
         self.close()
-        self.receiver = None  # Allow it to be garbage-collected
+        # Workaround for https://github.com/pytest-dev/pytest/issues/11374
+        self.receiver = None
 
     def close(self):
         if self.send_sock is not None:

--- a/tests/test_recv.py
+++ b/tests/test_recv.py
@@ -1246,6 +1246,7 @@ class TestTcpReader:
 
     def teardown_method(self):
         self.close()
+        self.receiver = None  # Allow it to be garbage-collected
 
     def close(self):
         if self.send_sock is not None:

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -605,7 +605,8 @@ class TestStream:
     def teardown_method(self):
         for thread in self.threads:
             thread.join()
-        self.stream = None  # Allow garbage collection
+        # Workaround for https://github.com/pytest-dev/pytest/issues/11374
+        self.stream = None
 
     def test_overflow(self):
         # Use threads to fill up the first two slots. This is necessary because
@@ -859,7 +860,7 @@ class TestInprocStream:
         self.stream = send.InprocStream(spead2.ThreadPool(), [self.queue])
 
     def teardown_method(self):
-        # Allow for garbage collection
+        # Workaround for https://github.com/pytest-dev/pytest/issues/11374
         self.queue = None
         self.stream = None
 

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -605,6 +605,7 @@ class TestStream:
     def teardown_method(self):
         for thread in self.threads:
             thread.join()
+        self.stream = None  # Allow garbage collection
 
     def test_overflow(self):
         # Use threads to fill up the first two slots. This is necessary because
@@ -856,6 +857,11 @@ class TestInprocStream:
         self.flavour = Flavour(4, 64, 48, 0)
         self.queue = spead2.InprocQueue()
         self.stream = send.InprocStream(spead2.ThreadPool(), [self.queue])
+
+    def teardown_method(self):
+        # Allow for garbage collection
+        self.queue = None
+        self.stream = None
 
     def test_stopped_queue(self):
         self.queue.stop()

--- a/tests/test_send_asyncio.py
+++ b/tests/test_send_asyncio.py
@@ -38,6 +38,9 @@ class TestUdpStream:
         self.ig["test"].value = np.zeros((256 * 1024,), np.uint8)
         self.heap = self.ig.get_heap()
 
+    def teardown_method(self):
+        self.stream = None  # Allow for garbage collection
+
     async def _test_async_flush(self):
         assert self.stream._active > 0
         await self.stream.async_flush()

--- a/tests/test_send_asyncio.py
+++ b/tests/test_send_asyncio.py
@@ -39,7 +39,8 @@ class TestUdpStream:
         self.heap = self.ig.get_heap()
 
     def teardown_method(self):
-        self.stream = None  # Allow for garbage collection
+        # Workaround for https://github.com/pytest-dev/pytest/issues/11374
+        self.stream = None
 
     async def _test_async_flush(self):
         assert self.stream._active > 0


### PR DESCRIPTION
This is a workaround for pytest-dev/pytest#11374. Closes #252.