### PR TITLE
Build wheels in fixed build directory on Linux

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -431,6 +431,8 @@ Other changes:
   (only happened when capturing to file).
 - Fix :program:`spead2_recv` reporting statistics that may miss out the last
   batch of packets.
+- Make source paths in :file:`.debug` files more usable (relative to
+  4.0.0b1).
 
 .. rubric:: 2.0.2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ setup-args = [
   "-Db_lto=true",
   "-Dpython_split_debug=true",
 ]
+builddir = "build-cibuildwheel"
 
 [tool.cibuildwheel.linux]
 archs = ["aarch64", "x86_64"]


### PR DESCRIPTION
This makes the debug info more usable, since it doesn't reference ephemeral build directories. See
https://github.com/mesonbuild/meson-python/issues/440#issuecomment-1702668770 for more info.