### PR TITLE
Use a more generic workaround for pytest-dev/pytest#11374

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+# Copyright 2023 National Research Foundation (SARAO)
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import inspect
+
+import pytest
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_teardown(item, nextitem):
+    # Workaround for https://github.com/pytest-dev/pytest/issues/11374
+    if inspect.ismethod(item.obj):
+        item.obj.__self__.__dict__.clear()

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -734,7 +734,3 @@ class TestPassthroughInproc(BaseTestPassthroughSubstreams):
         queues = [spead2.InprocQueue() for i in range(2)]
         stream = spead2.send.InprocStream(spead2.ThreadPool(), queues)
         assert stream.queues == queues
-
-    def teardown_method(self):
-        # Workaround for https://github.com/pytest-dev/pytest/issues/11374
-        getattr(self, "_queues", []).clear()

--- a/tests/test_passthrough_asyncio.py
+++ b/tests/test_passthrough_asyncio.py
@@ -205,7 +205,3 @@ class TestPassthroughInproc(BaseTestPassthroughSubstreamsAsync):
         for queue in self._queues:
             queue.stop()
         return ret
-
-    def teardown_method(self):
-        # Workaround for https://github.com/pytest-dev/pytest/issues/11374
-        getattr(self, "_queues", []).clear()

--- a/tests/test_recv.py
+++ b/tests/test_recv.py
@@ -1246,8 +1246,6 @@ class TestTcpReader:
 
     def teardown_method(self):
         self.close()
-        # Workaround for https://github.com/pytest-dev/pytest/issues/11374
-        self.receiver = None
 
     def close(self):
         if self.send_sock is not None:

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -605,8 +605,6 @@ class TestStream:
     def teardown_method(self):
         for thread in self.threads:
             thread.join()
-        # Workaround for https://github.com/pytest-dev/pytest/issues/11374
-        self.stream = None
 
     def test_overflow(self):
         # Use threads to fill up the first two slots. This is necessary because
@@ -858,11 +856,6 @@ class TestInprocStream:
         self.flavour = Flavour(4, 64, 48, 0)
         self.queue = spead2.InprocQueue()
         self.stream = send.InprocStream(spead2.ThreadPool(), [self.queue])
-
-    def teardown_method(self):
-        # Workaround for https://github.com/pytest-dev/pytest/issues/11374
-        self.queue = None
-        self.stream = None
 
     def test_stopped_queue(self):
         self.queue.stop()

--- a/tests/test_send_asyncio.py
+++ b/tests/test_send_asyncio.py
@@ -38,10 +38,6 @@ class TestUdpStream:
         self.ig["test"].value = np.zeros((256 * 1024,), np.uint8)
         self.heap = self.ig.get_heap()
 
-    def teardown_method(self):
-        # Workaround for https://github.com/pytest-dev/pytest/issues/11374
-        self.stream = None
-
     async def _test_async_flush(self):
         assert self.stream._active > 0
         await self.stream.async_flush()


### PR DESCRIPTION
Instead of selectively clearing members in teardown methods, just clear the whole object every time using a pytest hook.