### PR TITLE
Change .. code:: to .. code-block:: in Sphinx docs

### DIFF
--- a/doc/cpp-send.rst
+++ b/doc/cpp-send.rst
@@ -22,7 +22,7 @@ configuration and then use setters to set individual properties. The setters
 all return the configuration itself so that one can construct a configuration
 with a single expression such as
 
-.. code:: c++
+.. code-block:: c++
 
    spead2::send::stream_config().set_max_packet_size(9172).set_rate(1e9)
 

--- a/doc/dev-setup.rst
+++ b/doc/dev-setup.rst
@@ -24,14 +24,14 @@ that will use the files inside your working copy (recompiling C++ code if
 necessary), so that you don't need to explicitly install after each change.
 To do so, run
 
-.. code:: sh
+.. code-block:: sh
 
    pip install --no-build-isolation -e .
 
 See the meson-python_ documentation for more information about the limitations
 of editable installs. Also install the development runtime dependencies:
 
-.. code:: sh
+.. code-block:: sh
 
    pip install -r requirements.txt -r requirements-3.12.txt
 
@@ -96,7 +96,7 @@ The C++ code is less consistent in style, but here are some guidelines:
 - When two levels of namespaces start and end at the same point, use the
   C++17 nested namespace syntax:
 
-  .. code:: c++
+  .. code-block:: c++
 
      namespace spead2::recv
      {
@@ -116,7 +116,7 @@ The C++ code is less consistent in style, but here are some guidelines:
     cause type conversions if the type of the expression later changed.
   - The type is obvious from the initialiser, such as
 
-    .. code:: c++
+    .. code-block:: c++
 
        auto foo = std::make_unique<Foo>(1);
 

--- a/doc/migrate-3.rst
+++ b/doc/migrate-3.rst
@@ -10,7 +10,7 @@ To allow for code that wishes to support both version 3 and older versions,
 C++ macros are defined to allow the version number to be interrogated at
 compile time. Thus, version 3 can be detected as
 
-.. code:: c++
+.. code-block:: c++
 
    #if defined(SPEAD2_MAJOR) && SPEAD2_MAJOR >= 3
    // Version 3 or later
@@ -73,7 +73,7 @@ arguments. To make it convenient to construct temporaries, the
 setter methods return the object, allowing configurations to be constructed in
 a "fluent" style e.g.:
 
-.. code:: c++
+.. code-block:: c++
 
    spead2::send::stream_config().set_max_packet_size(9172).set_rate(1e6)
 

--- a/doc/py-logging.rst
+++ b/doc/py-logging.rst
@@ -6,6 +6,6 @@ debug logging is completely disabled for performance reasons. To enable
 it, you need to set the Meson option ``max_log_level=debug``. For example, if
 installing with :command:`pip`, use
 
-.. code:: sh
+.. code-block:: sh
 
    pip install --config-settings=setup-args=-Dmax_log_level=debug .

--- a/doc/tools.rst
+++ b/doc/tools.rst
@@ -132,7 +132,7 @@ program can be used to simplify running ibverbs applications. To use it, the
 program must first be given the capability. After installation, this can be
 done by running
 
-.. code:: sh
+.. code-block:: sh
 
    sudo setcap cap_net_raw+p /usr/local/bin/spead2_net_raw
 


### PR DESCRIPTION
While `code` seems to work, Sphinx documents `code-block`, and an alias `sourcecode`.