### PR TITLE
Eliminate deprecated boost::asio::null_buffers

### DIFF
--- a/include/spead2/recv_inproc.h
+++ b/include/spead2/recv_inproc.h
@@ -43,8 +43,7 @@ private:
     void packet_handler(
         handler_context ctx,
         stream_base::add_packet_state &state,
-        const boost::system::error_code &error,
-        std::size_t bytes_received);
+        const boost::system::error_code &error);
     void enqueue(handler_context ctx);
 
 public:

--- a/include/spead2/recv_udp_ibv.h
+++ b/include/spead2/recv_udp_ibv.h
@@ -229,8 +229,8 @@ void udp_ibv_reader_base<Derived>::enqueue_receive(handler_context ctx, bool nee
     if (comp_channel && !need_poll)
     {
         // Asynchronous mode
-        comp_channel_wrapper.async_read_some(
-            boost::asio::null_buffers(),
+        comp_channel_wrapper.async_wait(
+            comp_channel_wrapper.wait_read,
             bind_handler(
                 std::move(ctx),
                 std::bind(&udp_ibv_reader_base<Derived>::packet_handler, this, _1, _2, _3, true)));

--- a/src/recv_inproc.cpp
+++ b/src/recv_inproc.cpp
@@ -62,8 +62,7 @@ void inproc_reader::process_one_packet(stream_base::add_packet_state &state,
 void inproc_reader::packet_handler(
     handler_context ctx,
     stream_base::add_packet_state &state,
-    const boost::system::error_code &error,
-    [[maybe_unused]] std::size_t bytes_transferred)
+    const boost::system::error_code &error)
 {
     if (!error)
     {
@@ -92,9 +91,9 @@ void inproc_reader::packet_handler(
 void inproc_reader::enqueue(handler_context ctx)
 {
     using namespace std::placeholders;
-    data_sem_wrapper.async_read_some(
-        boost::asio::null_buffers(),
-        bind_handler(std::move(ctx), std::bind(&inproc_reader::packet_handler, this, _1, _2, _3, _4)));
+    data_sem_wrapper.async_wait(
+        data_sem_wrapper.wait_read,
+        bind_handler(std::move(ctx), std::bind(&inproc_reader::packet_handler, this, _1, _2, _3)));
 }
 
 void inproc_reader::stop()

--- a/src/recv_udp.cpp
+++ b/src/recv_udp.cpp
@@ -223,14 +223,18 @@ void udp_reader::packet_handler(
 void udp_reader::enqueue_receive(handler_context ctx)
 {
     using namespace std::placeholders;
-    socket.async_receive_from(
 #if SPEAD2_USE_RECVMMSG
-        boost::asio::null_buffers(),
+    socket.async_wait(
+        socket.wait_read,
+        bind_handler(std::move(ctx), std::bind(&udp_reader::packet_handler, this, _1, _2, _3, 0))
+    );
 #else
+    socket.async_receive_from(
         boost::asio::buffer(buffer.get(), max_size + 1),
-#endif
         sender_endpoint,
-        bind_handler(std::move(ctx), std::bind(&udp_reader::packet_handler, this, _1, _2, _3, _4)));
+        bind_handler(std::move(ctx), std::bind(&udp_reader::packet_handler, this, _1, _2, _3, _4))
+    );
+#endif
 }
 
 void udp_reader::stop()

--- a/src/send_udp.cpp
+++ b/src/send_udp.cpp
@@ -197,10 +197,10 @@ restart:
     {
         // We didn't manage to send it all: schedule a new attempt once there is
         // buffer space.
-        socket.async_send(
-            boost::asio::null_buffers(),
+        socket.async_wait(
+            socket.wait_write,
             [this, first_packet, last_packet, first_msg, last_msg](
-                const boost::system::error_code &, std::size_t
+                const boost::system::error_code &
             ) {
                 send_packets(first_packet, last_packet, first_msg, last_msg);
             });

--- a/src/send_udp_ibv.cpp
+++ b/src/send_udp_ibv.cpp
@@ -282,7 +282,7 @@ void udp_ibv_writer::wait_for_space()
     if (comp_channel)
     {
         send_cq.req_notify(false);
-        auto handler = [this](const boost::system::error_code &, size_t)
+        auto handler = [this](const boost::system::error_code &)
         {
             ibv_cq *event_cq;
             void *event_cq_context;
@@ -292,7 +292,7 @@ void udp_ibv_writer::wait_for_space()
                 send_cq.ack_events(1);
             wakeup();
         };
-        comp_channel_wrapper.async_read_some(boost::asio::null_buffers(), handler);
+        comp_channel_wrapper.async_wait(comp_channel_wrapper.wait_read, handler);
     }
     else
         post_wakeup();


### PR DESCRIPTION
Replace it with async_wait, which more directly captures the intent.