### PR TITLE
Make packet_generator::next_packet work in-place

### DIFF
--- a/include/spead2/send_packet.h
+++ b/include/spead2/send_packet.h
@@ -87,7 +87,7 @@ public:
      * If there are no more packets to send for the heap, an empty list is
      * returned.
      */
-    std::vector<boost::asio::const_buffer> next_packet(std::uint8_t *scratch);
+    void next_packet(std::uint8_t *scratch, std::vector<boost::asio::const_buffer> &out);
 };
 
 } // namespace spead2::send

--- a/src/py_send.cpp
+++ b/src/py_send.cpp
@@ -84,7 +84,8 @@ flavour heap_wrapper::get_flavour() const
 py::bytes packet_generator_next(packet_generator &gen)
 {
     auto scratch = spead2::detail::make_unique_for_overwrite<std::uint8_t[]>(gen.get_max_packet_size());
-    auto buffers = gen.next_packet(scratch.get());
+    std::vector<boost::asio::const_buffer> buffers;
+    gen.next_packet(scratch.get(), buffers);
     if (buffers.empty())
         throw py::stop_iteration();
     return py::bytes(std::string(boost::asio::buffers_begin(buffers),

--- a/src/send_packet.cpp
+++ b/src/send_packet.cpp
@@ -101,9 +101,9 @@ bool packet_generator::has_next_packet() const
     return payload_offset < payload_size;
 }
 
-std::vector<boost::asio::const_buffer> packet_generator::next_packet(std::uint8_t *scratch)
+void packet_generator::next_packet(std::uint8_t *scratch, std::vector<boost::asio::const_buffer> &out)
 {
-    std::vector<boost::asio::const_buffer> out;
+    out.clear();
 
     if (h.get_repeat_pointers())
     {
@@ -208,7 +208,6 @@ std::vector<boost::asio::const_buffer> packet_generator::next_packet(std::uint8_
             }
         }
     }
-    return out;
 }
 
 } // namespace spead2::send

--- a/src/send_writer.cpp
+++ b/src/send_writer.cpp
@@ -133,7 +133,7 @@ writer::packet_result writer::get_packet(transmit_packet &data, std::uint8_t *sc
     detail::queue_item *cur = get_owner()->get_queue(active);
     assert(cur->gen.has_next_packet());
 
-    data.buffers = cur->gen.next_packet(scratch);
+    cur->gen.next_packet(scratch, data.buffers);
     data.size = boost::asio::buffer_size(data.buffers);
     data.substream_index = cur->substream_index;
     // Point at the start of the group, so that errors and byte counts accumulate


### PR DESCRIPTION
Previously it returned a new vector, which was then assigned over a previous vector. That means incrementally allocating memory for the new vector, then freeing the original vector. It's more efficient to keep reusing the same vector object, which quickly grows to the size it needs to be, then doesn't require any further memory allocation.

This can improve throughput for 1472-byte packets by 20%.