### PR TITLE
Fix a couple of Python bindings for custom allocators

### DIFF
--- a/doc/py-recv.rst
+++ b/doc/py-recv.rst
@@ -362,7 +362,7 @@ for all allocators) is :py:class:`spead2.MemoryAllocator`, which has no
 constructor arguments or methods. An alternative is
 :py:class:`spead2.MmapAllocator`.
 
-.. py:class:: spead2.MmapAllocator(flags=0)
+.. py:class:: spead2.MmapAllocator(flags=0, prefer_huge=False)
 
     An allocator using :manpage:`mmap(2)`. This may be slightly faster for large
     allocations, and allows setting custom mmap flags. This is mainly intended
@@ -371,6 +371,9 @@ constructor arguments or methods. An alternative is
     :param int flags:
         Extra flags to pass to :manpage:`mmap(2)`. Finding the numeric values
         for OS-specific flags is left as a problem for the user.
+    :param bool prefer_huge:
+        If true, allocations will try to use huge pages (if supported by the
+        OS), and fall back to normal pages if that fails.
 
 The most important custom allocator is :py:class:`spead2.MemoryPool`. It allocates
 from a pool, rather than directly from the system. This can lead to

--- a/src/py_common.cpp
+++ b/src/py_common.cpp
@@ -299,14 +299,14 @@ void register_module(py::module m)
 
     py::class_<mmap_allocator, memory_allocator, std::shared_ptr<mmap_allocator>>(
         m, "MmapAllocator")
-        .def(py::init<int>(), "flags"_a=0);
+        .def(py::init<int, bool>(), "flags"_a=0, "prefer_huge"_a=false);
 
     py::class_<memory_pool, memory_allocator, std::shared_ptr<memory_pool>>(
         m, "MemoryPool")
         .def(py::init<std::size_t, std::size_t, std::size_t, std::size_t, std::shared_ptr<memory_allocator>>(),
              "lower"_a, "upper"_a, "max_free"_a, "initial"_a, py::arg_v("allocator", nullptr, "None"))
         .def(py::init<std::shared_ptr<thread_pool>, std::size_t, std::size_t, std::size_t, std::size_t, std::size_t, std::shared_ptr<memory_allocator>>(),
-             "thread_pool"_a, "lower"_a, "upper"_a, "max_free"_a, "initial"_a, "low_water"_a, "allocator"_a)
+             "thread_pool"_a, "lower"_a, "upper"_a, "max_free"_a, "initial"_a, "low_water"_a, py::arg_v("allocator", nullptr, "None"))
         .def_property("warn_on_empty",
                       &memory_pool::get_warn_on_empty, &memory_pool::set_warn_on_empty);
 

--- a/src/spead2/__init__.pyi
+++ b/src/spead2/__init__.pyi
@@ -86,7 +86,7 @@ class MemoryAllocator:
     def __init__(self) -> None: ...
 
 class MmapAllocator(MemoryAllocator):
-    def __init__(self, flags: int = ...) -> None: ...
+    def __init__(self, flags: int = ..., prefer_huge: bool = ...) -> None: ...
 
 class MemoryPool(MemoryAllocator):
     warn_on_empty: bool
@@ -109,7 +109,7 @@ class MemoryPool(MemoryAllocator):
         max_free: int,
         initial: int,
         low_water: int,
-        allocator: MemoryAllocator,
+        allocator: MemoryAllocator | None = None,
     ) -> None: ...
 
 class InprocQueue:


### PR DESCRIPTION
- MmapAllocator has an optional second parameter (prefer_huge)
- MemoryPool's allocator is an optional argument.