### PR TITLE
Update GH CI to use upload/download-artifact@v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -227,7 +227,7 @@ jobs:
         run: ./.ci/py-requirements.sh
       - run: pip install build==0.10.0
       - run: python -m build --sdist .
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: sdist
           path: ./dist/*.tar.gz
@@ -254,13 +254,13 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.python }}-manylinux*
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheel_linux-${{ matrix.arch }}-${{ matrix.python }}
           path: ./wheelhouse/*.whl
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: debug_symbols_uncompressed
+          name: debug_symbols_uncompressed-${{ matrix.arch }}-${{ matrix.python }}
           path: ./wheelhouse/*.debug
 
   cibuildwheel-macos:
@@ -282,23 +282,40 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.python }}-macos*
           CIBW_TEST_SKIP: "*-macosx_arm64"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheel_macos-${{ matrix.arch }}-${{ matrix.python }}
           path: ./wheelhouse/*.whl
 
-  compress-debug:
-    needs: [cibuildwheel-linux]
+  combine:
+    needs: [cibuildwheel-linux, cibuildwheel-macos, sdist]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - name: Create paths
+        run: mkdir -p debug-symbols dist wheelhouse
+      - uses: actions/download-artifact@v4
         with:
-          name: debug_symbols_uncompressed
+          pattern: debug_symbols_uncompressed-*
+          path: .
+          merge-multiple: true
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheel_*
+          path: wheelhouse/
+          merge-multiple: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist/
+          merge-multiple: true
       - name: Compress debug symbols
         run: >-
-          tar -Jcvf "spead2-"$(<VERSION.txt)-debug.tar.xz _spead2*.debug
-      - uses: actions/upload-artifact@v3
+          tar -Jcvf debug-symbols/"spead2-"$(<VERSION.txt)-debug.tar.xz _spead2*.debug
+      - uses: actions/upload-artifact@v4
         with:
-          name: debug_symbols
-          path: spead2-*-debug.tar.xz
+          name: combined
+          path: |
+            debug-symbols/
+            dist/
+            wheelhouse/


### PR DESCRIPTION
This required some structural changes, because v4 no longer allows multiple matrix jobs to upload to the same artifact and have the results merged. So instead every job creates its own artifact and there is a final merge process (which also handles combining the debug symbols into a tarball).