### PR TITLE
CI: use curl for downloads instead of wget

### DIFF
--- a/.ci/before_all_linux.sh
+++ b/.ci/before_all_linux.sh
@@ -10,25 +10,23 @@ pcap_version=1.10.4
 boost_version=1.83.0
 boost_version_under=${boost_version//./_}
 
-yum install -y wget cmake3 ninja-build flex bison libnl3-devel
-# Workaround for https://github.com/pypa/manylinux/issues/1203
-unset SSL_CERT_FILE
+yum install -y cmake3 ninja-build flex bison libnl3-devel
 
 cd /tmp
 
 # Install sccache
-wget --progress=dot:mega https://github.com/mozilla/sccache/releases/download/v${sccache_version}/sccache-v${sccache_version}-$(arch)-unknown-linux-musl.tar.gz
+curl -fsSLO https://github.com/mozilla/sccache/releases/download/v${sccache_version}/sccache-v${sccache_version}-$(arch)-unknown-linux-musl.tar.gz
 tar -zxf sccache-v${sccache_version}-$(arch)-unknown-linux-musl.tar.gz
 cp sccache-v${sccache_version}-$(arch)-unknown-linux-musl/sccache /usr/bin
 
 # Install boost
-wget --progress=dot:mega https://boostorg.jfrog.io/artifactory/main/release/${boost_version}/source/boost_${boost_version_under}.tar.bz2
+curl -fsSLO https://boostorg.jfrog.io/artifactory/main/release/${boost_version}/source/boost_${boost_version_under}.tar.bz2
 tar -jxf boost_${boost_version_under}.tar.bz2
 # Quick-n-dirty approach (much faster than doing the install, which copies thousands of files)
 ln -s /tmp/boost_${boost_version_under}/boost /usr/include/boost
 
 # Install rdma-core
-wget --progress=dot:mega https://github.com/linux-rdma/rdma-core/releases/download/v${rdma_core_version}/rdma-core-${rdma_core_version}.tar.gz
+curl -fsSLO https://github.com/linux-rdma/rdma-core/releases/download/v${rdma_core_version}/rdma-core-${rdma_core_version}.tar.gz
 tar -zxf /tmp/rdma-core-${rdma_core_version}.tar.gz
 cd rdma-core-${rdma_core_version}
 mkdir build
@@ -39,7 +37,7 @@ cd /tmp
 
 # Install pcap (the version provided by yum is old, and it gets vendored into
 # the wheel so it's worth keeping up to date).
-wget --progress=dot:mega https://www.tcpdump.org/release/libpcap-${pcap_version}.tar.gz
+curl -fsSLO https://www.tcpdump.org/release/libpcap-${pcap_version}.tar.gz
 tar -zxf /tmp/libpcap-${pcap_version}.tar.gz
 cd libpcap-${pcap_version}/
 # CFLAGS is set to avoid generating debug symbols (-g)
@@ -50,6 +48,6 @@ strip /usr/lib*/libpcap.so.*
 cd /tmp
 
 # Install libdivide
-wget https://raw.githubusercontent.com/ridiculousfish/libdivide/5.0/libdivide.h -O /usr/local/include/libdivide.h
+curl -fsSL https://raw.githubusercontent.com/ridiculousfish/libdivide/5.0/libdivide.h -o /usr/local/include/libdivide.h
 
 sccache --show-stats  # Check that sccache is being effective

--- a/.ci/before_all_macos.sh
+++ b/.ci/before_all_macos.sh
@@ -9,7 +9,7 @@ brew install boost@1.83 libdivide
 
 # Install pkgconfig from source - once for each architecture in CIBW_ARCHS
 cd /tmp
-wget --progress=dot:mega https://www.tcpdump.org/release/libpcap-${pcap_version}.tar.gz
+curl -fsSLO https://www.tcpdump.org/release/libpcap-${pcap_version}.tar.gz
 tar -zxf /tmp/libpcap-${pcap_version}.tar.gz
 cd libpcap-${pcap_version}/
 for arch in $CIBW_ARCHS; do


### PR DESCRIPTION
The aarch64 manylinux builds have started failing with errors about not trusting the certificate for www.tcpdump.org, and that doesn't seem to be a problem for curl. I've also had issues with wget and certificates in the past (https://github.com/pypa/manylinux/issues/1203), so I'm ditching it and going back to curl. It might be flakier since curl doesn't automatically retry if the connection drops partway through (it has a --retry option but that only retries on HTTP status codes that indicate a transient error).