### PR TITLE
Update boost to 1.84 for building wheels

### DIFF
--- a/.ci/before_all_linux.sh
+++ b/.ci/before_all_linux.sh
@@ -7,7 +7,7 @@ set -e -u
 sccache_version=0.5.4
 rdma_core_version=49.0
 pcap_version=1.10.4
-boost_version=1.83.0
+boost_version=1.84.0
 boost_version_under=${boost_version//./_}
 
 yum install -y cmake3 ninja-build flex bison libnl3-devel

--- a/.ci/before_all_macos.sh
+++ b/.ci/before_all_macos.sh
@@ -5,7 +5,7 @@ pcap_version=1.10.4
 
 # Prepare the MacOS environment for building spead2 wheels (for cibuildwheel)
 brew update
-brew install boost@1.83 libdivide
+brew install boost@1.84 libdivide
 
 # Install pkgconfig from source - once for each architecture in CIBW_ARCHS
 cd /tmp


### PR DESCRIPTION
This is necessitated by boost@1.83 disappearing from homebrew.