### PR TITLE
Switch to netifaces2

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+.. rubric:: Development version
+
+- Switch from netifaces to netifaces2 for testing.
+
 .. rubric:: 4.3.0
 
 - Add ability to override the transmission rate for individual heaps.

--- a/doc/py-ibverbs.rst
+++ b/doc/py-ibverbs.rst
@@ -14,12 +14,12 @@ There are a number of limitations in the current implementation:
 Within these limitations, it is quite easy to take advantage of this faster
 code path. The main difficulties are that one *must* specify the IP address of
 the interface that will send or receive the packets, and that the
-``CAP_NET_RAW`` capability may be needed. The netifaces_ module can
+``CAP_NET_RAW`` capability may be needed. The netifaces2_ module can
 help find the IP address for an interface by name, and the
 :ref:`spead2_net_raw` tool simplifies the process of getting the
 ``CAP_NET_RAW`` capability.
 
-.. _netifaces: https://pypi.python.org/pypi/netifaces
+.. _netifaces2: https://github.com/SamuelYvon/netifaces-2
 
 System configuration
 --------------------

--- a/requirements-3.12.txt
+++ b/requirements-3.12.txt
@@ -8,7 +8,7 @@ iniconfig==2.0.0
     # via pytest
 llvmlite==0.42.0
     # via numba
-netifaces==0.11.0
+netifaces2==0.0.21
     # via -r requirements.in
 numba==0.59.0
     # via -r requirements.in
@@ -32,3 +32,5 @@ pytest-timeout==2.2.0
     # via -r requirements.in
 scipy==1.12.0
     # via -r requirements.in
+typing-extensions==4.9.0
+    # via netifaces2

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-netifaces
+netifaces2
 numba
 numpy
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ iniconfig==2.0.0
     # via pytest
 llvmlite==0.41.1
     # via numba
-netifaces==0.11.0
+netifaces2==0.0.21
     # via -r requirements.in
 numba==0.58.1
     # via -r requirements.in
@@ -38,5 +38,7 @@ scipy==1.10.1
     # via -r requirements.in
 tomli==2.0.1
     # via pytest
+typing-extensions==4.9.0
+    # via netifaces2
 zipp==3.17.0
     # via importlib-metadata

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ python_requires = >=3.8
 install_requires =
     numpy>=1.9.2
 tests_require =
-    netifaces
+    netifaces2
     numba
     pytest
     pytest-asyncio

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -1,4 +1,4 @@
-# Copyright 2015, 2019-2023 National Research Foundation (SARAO)
+# Copyright 2015, 2019-2024 National Research Foundation (SARAO)
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -15,6 +15,7 @@
 
 """Test that data can be passed over the SPEAD protocol using the various transports."""
 
+import functools
 import ipaddress
 import os
 import socket
@@ -555,11 +556,12 @@ class TestPassthroughUdp6Multicast(TestPassthroughUdp6):
     requires_ipv6_multicast = True
     MCAST_GROUP = "ff14::1234"
 
-    @classmethod
-    def get_interface_index(cls):
+    @staticmethod
+    @functools.lru_cache  # Cache to guarantee that calls get consistent results
+    def get_interface_index():
         if not hasattr(socket, "if_nametoindex"):
             pytest.skip("socket.if_nametoindex does not exist")
-        for iface in netifaces.interfaces():
+        for iface in sorted(netifaces.interfaces()):  # Sort to give repeatable results
             addrs = netifaces.ifaddresses(iface).get(netifaces.AF_INET6, [])
             for addr in addrs:
                 if addr["addr"] != "::1":


### PR DESCRIPTION
netifaces is deprecated.

netifaces2 seems to have non-deterministic iteration order, which was causing the senders and receivers in TestPassthroughUdp6Multicast to use a different interface. Fix by adding @functools.lru_cache to cache the result after the first call.