### PR TITLE
Switch to coverallsapp/github-action@v2.2.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,7 @@ jobs:
         run: meson test -C build
       - name: Collect coverage
         run: ./.ci/coverage.sh
-      - uses: coverallsapp/github-action@master
+      - uses: coverallsapp/github-action@v2.2.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: lcov.info


### PR DESCRIPTION
It was previous using the `master` branch, but the repo now has a more recent `main` branch. Rather than deal with that mess, just switch to a tagged release. This will hopefully address the warnings about node v16 being deprecated.