### PR TITLE
Implement support for generic receive offload

### DIFF
--- a/.ci/all-builds.sh
+++ b/.ci/all-builds.sh
@@ -24,4 +24,11 @@ for python in true false; do
             meson compile
         done
     done
+    # Similar recvmmsg and gro don't interact with either of the above
+    for recvmmsg in auto disabled; do
+        for gro in auto disabled; do
+            meson configure -Dpython=$python -Drecvmmsg=$recvmmsg -Dgro=$gro
+            meson compile
+        done
+    done
 done

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+.. rubric:: Development version
+
+- Speed up receiving UDP with the Linux kernel network stack by using
+  generic receive offload (GRO).
+
 .. rubric:: 4.3.1
 
 - Switch from netifaces to netifaces2 for testing.

--- a/include/spead2/common_features.h.in
+++ b/include/spead2/common_features.h.in
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2017, 2019-2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2015, 2017, 2019-2020, 2023-2024 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -34,6 +34,7 @@
 #define SPEAD2_USE_RECVMMSG @SPEAD2_USE_RECVMMSG@
 #define SPEAD2_USE_SENDMMSG @SPEAD2_USE_SENDMMSG@
 #define SPEAD2_USE_GSO @SPEAD2_USE_GSO@
+#define SPEAD2_USE_GRO @SPEAD2_USE_GRO@
 #define SPEAD2_USE_EVENTFD @SPEAD2_USE_EVENTFD@
 #define SPEAD2_USE_PTHREAD_SETAFFINITY_NP @SPEAD2_USE_PTHREAD_SETAFFINITY_NP@
 #define SPEAD2_USE_FMV @SPEAD2_USE_FMV@

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-# Copyright 2023 National Research Foundation (SARAO)
+# Copyright 2023-2024 National Research Foundation (SARAO)
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -167,6 +167,13 @@ use_gso = get_option('gso').require(
     prefix : '#include <netinet/udp.h>'
   ) != ''
 ).allowed()
+use_gro = get_option('gro').require(
+  compiler.get_define(
+    'UDP_GRO',
+    args : '-D_GNU_SOURCE',
+    prefix : '#include <netinet/udp.h>'
+  ) != ''
+).allowed()
 use_eventfd = get_option('eventfd').require(
   compiler.has_function(
     'eventfd',
@@ -268,6 +275,7 @@ conf.set10('SPEAD2_USE_MLX5DV', mlx5_dep.found())
 conf.set10('SPEAD2_USE_RECVMMSG', use_recvmmsg)
 conf.set10('SPEAD2_USE_SENDMMSG', use_sendmmsg)
 conf.set10('SPEAD2_USE_GSO', use_gso)
+conf.set10('SPEAD2_USE_GRO', use_gro)
 conf.set10('SPEAD2_USE_EVENTFD', use_eventfd)
 conf.set10('SPEAD2_USE_POSIX_SEMAPHORES', use_posix_semaphores)
 conf.set10('SPEAD2_USE_PTHREAD_SETAFFINITY_NP', use_pthread_setaffinity_np)

--- a/meson.options
+++ b/meson.options
@@ -1,4 +1,4 @@
-# Copyright 2023 National Research Foundation (SARAO)
+# Copyright 2023-2024 National Research Foundation (SARAO)
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -22,6 +22,7 @@ option('cap', type : 'feature', description : 'Use libcap')
 option('recvmmsg', type : 'feature', description : 'Use recvmmsg system call')
 option('sendmmsg', type : 'feature', description : 'Use sendmmsg system call')
 option('gso', type : 'feature', description : 'Use generic segmentation offload')
+option('gro', type : 'feature', description : 'Use generic receive offload')
 option('eventfd', type : 'feature', description : 'Use eventfd system call for semaphores')
 option('posix_semaphores', type : 'feature', description : 'Use POSIX semaphores')
 option('pthread_setaffinity_np', type : 'feature', description : 'Use pthread_setaffinity_np to set thread affinity')


### PR DESCRIPTION
GRO allows a socket to opt in to having the kernel group together packets with the same header information (source, destination, size etc) into one jumbo packet. The original packet size is provided as ancillary data to allow userspace to reconstruct the original packets. This can provide around a 20% speedup.