### PR TITLE
Update CI builds on MacOS

### DIFF
--- a/.ci/before_all_macos.sh
+++ b/.ci/before_all_macos.sh
@@ -4,35 +4,19 @@ set -e -u
 pcap_version=1.10.4
 
 # Prepare the MacOS environment for building spead2 wheels (for cibuildwheel)
-brew update
-brew install boost@1.84 libdivide
+.ci/install-sys-pkgs.sh
 
-# Install pkgconfig from source - once for each architecture in CIBW_ARCHS
+# Install libpcap from source
 cd /tmp
 curl -fsSLO https://www.tcpdump.org/release/libpcap-${pcap_version}.tar.gz
 tar -zxf /tmp/libpcap-${pcap_version}.tar.gz
 cd libpcap-${pcap_version}/
-for arch in $CIBW_ARCHS; do
-    mkdir build-$arch
-    cd build-$arch
-    if [ "$arch" == $(arch) ]; then
-        host_args=""
-    else
-        host_args="--host=$arch-apple-darwin"
-    fi
-    # CFLAGS is set to avoid generating debug symbols (-g)
-    ../configure $host_args --prefix=/tmp/cibuildwheel/$arch --disable-rdma --disable-universal --without-libnl \
-        CC="sccache cc -arch $arch" CFLAGS="-O2"
-    make -j
-    make install
-    strip -S -x /tmp/cibuildwheel/$arch/lib*/libpcap.*
-    cd ..
-done
-
-# Set up meson cross file to pick up pcap-config. Meson refuses to use the one
-# in $PATH when cross-compiling.
-cat > /tmp/cibuildwheel/pcap-cross.ini <<EOF
-[binaries]
-pcap-config = '/tmp/cibuildwheel/$CIBW_ARCHS/bin/pcap-config'
-strip = 'strip'
-EOF
+mkdir build
+cd build
+prefix="$(brew --prefix)"
+# CFLAGS is set to avoid generating debug symbols (-g)
+../configure --prefix="$prefix" --disable-rdma --disable-universal --without-libnl \
+    CC="sccache cc" CFLAGS="-O2"
+make -j
+make install
+strip -S -x "$prefix"/lib*/libpcap.*

--- a/.ci/install-sys-pkgs.sh
+++ b/.ci/install-sys-pkgs.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# Create this just for consistency with the MacOS native file
+mkdir -p $HOME/.local/share/meson/native
+touch $HOME/.local/share/meson/native/ci.ini
+
 if [ "$(uname -s)" = "Linux" ]; then
     sudo apt-get install \
         ninja-build \
@@ -16,5 +20,17 @@ if [ "$(uname -s)" = "Linux" ]; then
         libibverbs-dev \
         libdivide-dev
 else
-    brew install ninja boost libdivide
+    brew update
+    brew install ninja boost@1.84 libdivide
+    # On Apple Silicon, homebrew is installed in /opt/homebrew, but the
+    # toolchains are not configured to find things there.
+    prefix="$(brew --prefix)"
+    cat > $HOME/.local/share/meson/native/ci.ini <<EOF
+[properties]
+boost_root = '$prefix'
+
+[built-in options]
+cpp_args = ['-I$prefix/include']
+cpp_link_args = ['-L$prefix/lib']
+EOF
 fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           - os: ubuntu-22.04
             cxx: clang++-14
             extras: enabled
-          - os: macos-12
+          - os: macos-14
             cxx: clang++
             extras: disabled
     runs-on: ${{ matrix.os }}
@@ -38,13 +38,15 @@ jobs:
         run: ./.ci/install-sys-pkgs.sh
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          # 3.10 is the minimum version supported on macos-14 builders
+          python-version: '3.10'
           cache: 'pip'
       - name: Install build requirements
         run: ./.ci/py-build-requirements.sh
       - name: Set up build directory
         run: >-
           meson setup build
+          --native-file=ci.ini
           -Dwerror=true
           -Dauto_features=${{ matrix.extras }}
           -Dcuda=disabled
@@ -86,7 +88,7 @@ jobs:
             cxx: clang++-14
             python-version: '3.12'
             extras: enabled
-          - os: macos-12
+          - os: macos-14
             cc: clang
             cxx: clang++
             python-version: '3.12'
@@ -114,6 +116,7 @@ jobs:
       - name: Install Python package
         run: >-
           pip install -v
+          --config-settings=setup-args=--native-file=ci.ini
           --config-settings=setup-args=-Dwerror=true
           --config-settings=setup-args=-Dauto_features=${{ matrix.extras }}
           --config-settings=setup-args=-Dfmv="$(if [[ '${{ matrix.cxx }}' == g++* ]]; then echo enabled; else echo disabled; fi)"
@@ -250,7 +253,7 @@ jobs:
         with:
           platforms: arm64
         if: matrix.arch != 'x86_64'
-      - uses: pypa/cibuildwheel@v2.16.5
+      - uses: pypa/cibuildwheel@v2.17.0
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.python }}-manylinux*
@@ -265,26 +268,29 @@ jobs:
 
   cibuildwheel-macos:
     needs: [test-cxx, test-python, coverage, lint]
-    runs-on: macos-12
     strategy:
       fail-fast: false
       matrix:
-        arch: [x86_64, arm64]
+        os: [macos-13, macos-14]
         python: [cp38, cp39, cp310, cp311, cp312]
+        exclude:
+          # Python 3.8 not natively available for Apple Silicon. cibuildwheel
+          # tries to do a cross build, which fails.
+          - os: macos-14
+            python: cp38
+    runs-on: ${{ matrix.os }}
     env:
       SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v4
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.4
-      - uses: pypa/cibuildwheel@v2.16.5
+      - uses: pypa/cibuildwheel@v2.17.0
         env:
-          CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.python }}-macos*
-          CIBW_TEST_SKIP: "*-macosx_arm64"
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel_macos-${{ matrix.arch }}-${{ matrix.python }}
+          name: wheel_macos-${{ matrix.os }}-${{ matrix.python }}
           path: ./wheelhouse/*.whl
 
   combine:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ before-all = ".ci/before_all_linux.sh"
 setup-args = [
   "-Dpcap=enabled",
   "-Db_lto=true",
-  "--cross-file=/tmp/cibuildwheel/pcap-cross.ini",
+  "--native-file=ci.ini",
 ]
 
 [tool.cibuildwheel.macos]

--- a/src/common_memory_pool.cpp
+++ b/src/common_memory_pool.cpp
@@ -98,7 +98,7 @@ memory_pool::memory_pool(
     int)
     : io_service(std::move(io_service)), lower(lower), upper(upper), max_free(max_free),
     initial(initial), low_water(low_water),
-    base_allocator(allocator ? move(allocator) : std::make_shared<memory_allocator>())
+    base_allocator(allocator ? std::move(allocator) : std::make_shared<memory_allocator>())
 {
     assert(lower <= upper);
     assert(initial <= max_free);


### PR DESCRIPTION
- Run tests on macos-14 (Apple Silicon)
- Build x86_64 wheels on macos-13 and arm64 wheels on macos-14, so that
  you're doing native builds in each case. This simplifies the
  installation of libpcap since it's no longer necessary to cross-build
  it, and allows the arm64 wheels to be tested.
- Create a meson 'native' file which tells the compiler where to find
  Boost, includes and libraries on Homebrew. This is needed for Apple
  Silicon builds because Homebrew stuff goes into /opt/homebrew and the
  tools don't know about that.
- Update cibuildwheel to 2.17.0
- Unify some code between .ci/install-sys-pkgs.sh and
  .ci/before_all_macos.sh.

One regression with this change is that Python 3.8 wheels are no longer
produced for Apple Silicon. I'm guessing that this configuration is not
going to be in demand given that Apple Silicon support was first added
in Python 3.9 and only later backported to 3.8.