### PR TITLE
Fix incompatibilities with numpy 2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         # TODO: unify the versions once Python 3.8 support is dropped
         additional_dependencies: [
           'numpy==1.24.4; python_version<"3.12.0rc1"',
-          'numpy==1.26.3; python_version>="3.12.0rc1"'
+          'numpy==2.0.0; python_version>="3.12.0rc1"'
         ]
   - repo: https://github.com/jazzband/pip-tools
     rev: 7.1.0

--- a/requirements-3.12.txt
+++ b/requirements-3.12.txt
@@ -12,7 +12,7 @@ netifaces2==0.0.22
     # via -r requirements.in
 numba==0.60.0
     # via -r requirements.in
-numpy==1.26.4
+numpy==2.0.0
     # via
     #   -r requirements.in
     #   numba

--- a/requirements-readthedocs.txt
+++ b/requirements-readthedocs.txt
@@ -39,7 +39,7 @@ netifaces2==0.0.22
     # via -r requirements-3.12.txt
 numba==0.60.0
     # via -r requirements-3.12.txt
-numpy==1.26.4
+numpy==2.0.0
     # via
     #   -r requirements-3.12.txt
     #   numba


### PR DESCRIPTION
- np.lib.utils.safe_eval has been removed in favour of ast.literal_eval
- np.array(..., copy=False) now errors out if a copy is required, whereas numpy 1.x would fall back to copying. We were depending on the fallback.
- Encoding floats on the slow path was incorrectly mixing numpy scalars into what should have been a pure Python calculation. It's not clear how this wasn't failing on numpy 1.26, which doesn't allow bitwise OR between np.uint64 and Python scalars.