### PR TITLE
fixed the PDF version generation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,6 +48,7 @@ version, release = get_version()
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.imgconverter",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",


### PR DESCRIPTION
When I try to download the PDF version in [spead2](https://spead2.readthedocs.io/_/downloads/en/latest/pdf/),
It crashed. After checking the compile log, it looks like the error was caused by the SVG file.

```
! LaTeX Error: Cannot determine size of graphic in *.svg
```

This should fix the PDF generation host on the readthedocs.io, it works on my laptop at least.