### PR TITLE
Fix PDF docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,7 @@ build:
     - libboost-dev
     - libdivide-dev
     - pdf2svg
+    - inkscape
   tools:
     python: "3.12"
 python:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -52,6 +52,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinxcontrib.tikz",
+    "sphinxcontrib.inkscapeconverter",
     "sphinx_design",
     "sphinx_rtd_theme",
     "breathe",

--- a/requirements-readthedocs.in
+++ b/requirements-readthedocs.in
@@ -2,5 +2,6 @@ sphinx
 sphinx-design
 sphinx-rtd-theme
 sphinxcontrib-tikz
+sphinxcontrib-svg2pdfconverter
 breathe
 -r requirements.txt

--- a/requirements-readthedocs.txt
+++ b/requirements-readthedocs.txt
@@ -40,6 +40,7 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
+sphinxcontrib-svg2pdfconverter==1.2.3
 sphinxcontrib-tikz==0.4.20
 tomli==2.0.2
 urllib3==2.2.2


### PR DESCRIPTION
Use sphinxcontrib-svg2pdfconverter to convert SVG images to PDF for inclusion in the PDF build.