### PR TITLE
Add asyncio_default_fixture_loop_scope to pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function


### PR DESCRIPTION
There was a warning with it missing.