### PR TITLE
Shift a couple of stages from Jenkinsfile into Dockerfile

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -21,20 +21,9 @@
 FROM ubuntu:24.04
 
 WORKDIR /tmp/spead2
-COPY . .
+COPY .ci/install-sys-pkgs.sh .
 
 # Install dependencies
 # jq and iproute2 are used to find the interface IPv4 address
 RUN apt-get update && apt-get -y --no-install-recommends install libpython3-dev python3-venv jq iproute2
-RUN python3 -m venv /venv
 RUN .ci/install-sys-pkgs.sh
-RUN PATH="/venv/bin:$PATH" .ci/py-requirements.sh
-
-# Install Python package
-RUN PATH="/venv/bin:$PATH" pip install -v \
-    --config-settings=setup-args=--native-file=ci.ini \
-    --config-settings=setup-args=-Dibv=enabled \
-    --config-settings=setup-args=-Dibv_hw_rate_limit=enabled \
-    --config-settings=setup-args=-Dmlx5dv=enabled \
-    .
-

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -27,3 +27,7 @@ COPY install-sys-pkgs.sh .
 # jq and iproute2 are used to find the interface IPv4 address
 RUN apt-get update && apt-get -y --no-install-recommends install libpython3-dev python3-venv jq iproute2
 RUN ./install-sys-pkgs.sh
+
+RUN python3 -m venv /venv
+RUN chown -R +1000:+1000 /venv
+ENV PATH=/venv/bin:$PATH

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,8 +1,7 @@
 # syntax = docker/dockerfile:1
 
 ################################################################################
-# Copyright (c) 2024, National Research Foundation (SARAO)
-#
+# Copyright 2024 National Research Foundation (SARAO)
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -21,7 +21,7 @@
 FROM ubuntu:24.04
 
 WORKDIR /tmp/spead2
-COPY .ci/install-sys-pkgs.sh .
+COPY install-sys-pkgs.sh .
 
 # Install dependencies
 # jq and iproute2 are used to find the interface IPv4 address

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -26,4 +26,4 @@ COPY install-sys-pkgs.sh .
 # Install dependencies
 # jq and iproute2 are used to find the interface IPv4 address
 RUN apt-get update && apt-get -y --no-install-recommends install libpython3-dev python3-venv jq iproute2
-RUN .ci/install-sys-pkgs.sh
+RUN ./install-sys-pkgs.sh

--- a/Dockerfile.CI
+++ b/Dockerfile.CI
@@ -1,0 +1,40 @@
+# syntax = docker/dockerfile:1
+
+################################################################################
+# Copyright (c) 2024, National Research Foundation (SARAO)
+#
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+FROM ubuntu:24.04
+
+WORKDIR /tmp/spead2
+COPY . .
+
+# Install dependencies
+# jq and iproute2 are used to find the interface IPv4 address
+RUN apt-get update && apt-get -y --no-install-recommends install libpython3-dev python3-venv jq iproute2
+RUN python3 -m venv /venv
+RUN .ci/install-sys-pkgs.sh
+RUN PATH="/venv/bin:$PATH" .ci/py-requirements.sh
+
+# Install Python package
+RUN PATH="/venv/bin:$PATH" pip install -v \
+    --config-settings=setup-args=--native-file=ci.ini \
+    --config-settings=setup-args=-Dibv=enabled \
+    --config-settings=setup-args=-Dibv_hw_rate_limit=enabled \
+    --config-settings=setup-args=-Dmlx5dv=enabled \
+    .
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,8 +44,7 @@ pipeline {
   stages {
     stage('Install dependencies') {
       steps {
-        sh 'python3 -m venv /venv'
-        sh 'PATH="/venv/bin:$PATH" py-requirements.sh'
+        sh '.ci/py-requirements.sh'
 
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,10 +23,10 @@
 
 pipeline {
   agent {
-    docker {
+    dockerfile {
       label 'spead2'
+      filename 'Dockerfile.CI'
       registryCredentialsId 'dockerhub'  // Supply credentials to avoid rate limit
-      image 'ubuntu:24.04'
       // These arguments allow direct access to the NVIDIA NIC with ibverbs
       args '--network=host --ulimit=memlock=-1 -e NVIDIA_MOFED=enabled -e NVIDIA_VISIBLE_DEVICES=all --runtime=nvidia'
     }
@@ -42,26 +42,6 @@ pipeline {
   }
 
   stages {
-    stage('Install dependencies') {
-      steps {
-        // jq and iproute2 are used to find the interface IPv4 address
-        sh 'apt-get update && apt-get -y --no-install-recommends install libpython3-dev python3-venv jq iproute2'
-        sh 'python3 -m venv /venv'
-        sh '.ci/install-sys-pkgs.sh'
-        sh 'PATH="/venv/bin:$PATH" .ci/py-requirements.sh'
-      }
-    }
-
-    stage('Install Python package') {
-      steps {
-        sh '''PATH="/venv/bin:$PATH" pip install -v \
-          --config-settings=setup-args=--native-file=ci.ini \
-          --config-settings=setup-args=-Dibv=enabled \
-          --config-settings=setup-args=-Dibv_hw_rate_limit=enabled \
-          --config-settings=setup-args=-Dmlx5dv=enabled \
-          .'''
-      }
-    }
 
     stage('Run tests') {
       steps {


### PR DESCRIPTION
The Jenkins job on our new deployment is running Docker containers with the option `-u 1000:1000` instead of `-u 0:0` which results in permissions issues when doing administrative things such as using `apt-get` to install stuff.

So this commit moves the install stages of the test run into a Dockerfile, so that the image which is all nicely configured can then be used to run the tests.

Relates to NGC-1447.