### PR TITLE
Rework for Jenkins testing

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -27,7 +27,3 @@ COPY install-sys-pkgs.sh .
 # jq and iproute2 are used to find the interface IPv4 address
 RUN apt-get update && apt-get -y --no-install-recommends install libpython3-dev python3-venv jq iproute2
 RUN ./install-sys-pkgs.sh
-
-RUN python3 -m venv /venv
-RUN chown -R +1000:+1000 /venv
-ENV PATH=/venv/bin:$PATH

--- a/.ci/install-sys-pkgs.sh
+++ b/.ci/install-sys-pkgs.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -e
 
-# Create this just for consistency with the MacOS native file
-mkdir -p $HOME/.local/share/meson/native
-touch $HOME/.local/share/meson/native/ci.ini
-
 if [ "$(uname -s)" = "Linux" ]; then
     SUDO=sudo
     if [ `id -u` -eq 0 ]; then
@@ -31,6 +27,7 @@ else
     # On Apple Silicon, homebrew is installed in /opt/homebrew, but the
     # toolchains are not configured to find things there.
     prefix="$(brew --prefix)"
+    mkdir -p $HOME/.local/share/meson/native
     cat > $HOME/.local/share/meson/native/ci.ini <<EOF
 [properties]
 boost_root = '$prefix'

--- a/.ci/setup-flags.sh
+++ b/.ci/setup-flags.sh
@@ -5,7 +5,6 @@
 # include them because the detection code is broken.
 
 flags=(
-    "--native-file=ci.ini"
     "-Dwerror=true"
     "-Dtools=enabled"
     "-Dpcap=enabled"
@@ -27,6 +26,8 @@ if [ "$(uname)" = "Linux" ]; then
         "-Dposix_semaphores=enabled"
         "-Deventfd=enabled"
     )
+else
+    flags+=("--native-file=ci.ini")
 fi
 
 case "$(arch)" in

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,25 +44,20 @@ pipeline {
   stages {
     stage('Install dependencies') {
       steps {
-        sh '.ci/py-requirements.sh'
-
+        sh 'python3 -m venv ./.venv'
+        sh 'PATH="$PWD/.venv/bin:$PATH" .ci/py-requirements.sh'
       }
     }
     stage('Install Python package') {
       steps {
-        sh '''PATH="/venv/bin:$PATH" pip install -v \
-          --config-settings=setup-args=--native-file=ci.ini \
-          --config-settings=setup-args=-Dibv=enabled \
-          --config-settings=setup-args=-Dibv_hw_rate_limit=enabled \
-          --config-settings=setup-args=-Dmlx5dv=enabled \
-          .'''
+        sh 'PATH="$PWD/.venv/bin:$PATH" pip install -v $(.ci/setup-flags.sh --python) .'
       }
     }
     stage('Run tests') {
       steps {
-        sh 'PATH="/venv/bin:$PATH" .ci/py-tests-jenkins.sh'
+        sh 'PATH="$PWD/.venv/bin:$PATH" .ci/py-tests-jenkins.sh'
         junit 'results.xml'
-        sh 'PATH="/venv/bin:$PATH" .ci/py-tests-shutdown.sh'
+        sh 'PATH="$PWD/.venv/bin:$PATH" .ci/py-tests-shutdown.sh'
       }
     }
   }


### PR DESCRIPTION
- Move venv creation back to Jenkinsfile, and create it inside the workspace
- Remove native.ini for Linux and use it on MacOS only
- Update Jenkins install step to use setup-flags.sh.