### PR TITLE
Jenkins: try to obtain cap_net_raw

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -26,3 +26,6 @@ COPY install-sys-pkgs.sh .
 # jq and iproute2 are used to find the interface IPv4 address
 RUN apt-get update && apt-get -y --no-install-recommends install libpython3-dev python3-venv jq iproute2
 RUN ./install-sys-pkgs.sh
+
+# Give setpriv the ability to run commands with CAP_NET_RAW capability
+RUN setcap cap_net_raw+p /usr/bin/setpriv

--- a/.ci/py-tests-jenkins.sh
+++ b/.ci/py-tests-jenkins.sh
@@ -21,4 +21,5 @@ echo "Testing with device $device address $address"
 # -ra summarises the reasons for skipping or failing tests
 # We suppress the exit code so that the following test publishing step
 # is allowed to run if there are failing tests.
-pytest -v -ra --junitxml=results.xml --suppress-tests-failed-exit-code
+setpriv --inh-caps +net_raw --ambient-caps +net_raw -- \
+    pytest -v -ra --junitxml=results.xml --suppress-tests-failed-exit-code


### PR DESCRIPTION
setpriv isn't quite as convenient to use as spead2_net_raw (being more general purpose), but it has the advantage of already being installed and hence we don't need to mess around compiling the spead2 C++ tool suite.