### PR TITLE
Support Boost 1.87

### DIFF
--- a/.ci/before_all_linux.sh
+++ b/.ci/before_all_linux.sh
@@ -7,7 +7,7 @@ set -e -u
 sccache_version=0.5.4
 rdma_core_version=53.0
 pcap_version=1.10.5
-boost_version=1.86.0
+boost_version=1.87.0
 boost_version_under=${boost_version//./_}
 
 yum install -y cmake3 ninja-build flex bison libnl3-devel

--- a/.ci/before_all_linux.sh
+++ b/.ci/before_all_linux.sh
@@ -20,7 +20,7 @@ tar -zxf sccache-v${sccache_version}-$(arch)-unknown-linux-musl.tar.gz
 cp sccache-v${sccache_version}-$(arch)-unknown-linux-musl/sccache /usr/bin
 
 # Install boost
-curl -fsSLO https://boostorg.jfrog.io/artifactory/main/release/${boost_version}/source/boost_${boost_version_under}.tar.bz2
+curl -fsSLO https://archives.boost.io/release/${boost_version}/source/boost_${boost_version_under}.tar.bz2
 tar -jxf boost_${boost_version_under}.tar.bz2
 # Quick-n-dirty approach (much faster than doing the install, which copies thousands of files)
 ln -s /tmp/boost_${boost_version_under}/boost /usr/include/boost

--- a/.ci/install-sys-pkgs.sh
+++ b/.ci/install-sys-pkgs.sh
@@ -21,7 +21,7 @@ if [ "$(uname -s)" = "Linux" ]; then
         libdivide-dev
 else
     brew update
-    brew install ninja boost@1.86 libdivide
+    brew install ninja boost@1.87 libdivide
     # The MacOS images have an outdated Rust and the line above breaks it.
     brew upgrade rustup
     # On Apple Silicon, homebrew is installed in /opt/homebrew, but the

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+.. rubric:: Development version
+
+- Bump minimum Boost version to 1.70 (this was the practical lower limit,
+  as it wasn't compiling against older versions).
+- Support Boost 1.87.
+- Rename :cpp:class:`!spead2::io_service_ref` to
+  :cpp:class:`spead2::io_context_ref` to reflect name changes in Asio (the old
+  name is retained as a typedef).
+- Rename methods called :func:`!get_io_service` to :func:`!get_io_context`,
+  again to reflect name changes in Boost.
+- Update URL to download Boost in cibuildwheel configuration.
+
 .. rubric:: 4.3.2
 
 - Speed up receiving UDP with the Linux kernel network stack by using

--- a/doc/cpp-asio.rst
+++ b/doc/cpp-asio.rst
@@ -10,19 +10,19 @@ avoid multi-threading issues.
    :members:
 
 Classes that perform asynchronous operations take a parameter of type
-:cpp:class:`spead2::io_service_ref`. This can be (implicitly) initialised from
-either a :cpp:class:`boost::asio::io_service` reference, a
+:cpp:class:`spead2::io_context_ref`. This can be (implicitly) initialised from
+either a :cpp:class:`boost::asio::io_context` reference, a
 :cpp:class:`spead2::thread_pool` reference, or a
 :cpp:class:`std::shared_ptr\<spead2::thread_pool\>`. In the last case, the
 receiving class retains a copy of the shared pointer, providing convenient
 lifetime management of a thread pool.
 
-.. doxygenclass:: spead2::io_service_ref
+.. doxygenclass:: spead2::io_context_ref
    :members:
 
 A number of the APIs use callbacks. These follow the usual Boost.Asio
 guarantee that they will always be called from threads running
-:cpp:func:`boost::asio::io_service::run`. If using a
+:cpp:func:`boost::asio::io_context::run`. If using a
 :cpp:class:`~spead2::thread_pool`, this will be one of the threads managed by
 the pool. Additionally, callbacks for a specific stream are serialised, but
 there may be concurrent callbacks associated with different streams.

--- a/doc/dev-recv-locking.rst
+++ b/doc/dev-recv-locking.rst
@@ -9,7 +9,7 @@ let's introduce some terminology: the user writes code which runs on a thread,
 which we'll call the "user thread" (there may be multiple user threads, but
 for most functions it's only safe for one user thread at a time to interact
 with a stream). The threads in a :py:class:`.ThreadPool`, or more generally
-threads running :cpp:func:`boost::asio::io_service::run` (or equivalents) are
+threads running :cpp:func:`boost::asio::io_context::run` (or equivalents) are
 "worker threads".
 
 The original sin that leads to many complications is

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -55,7 +55,7 @@ Python install from source
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Installing from source requires a modern C++ compiler supporting C++17 (GCC
 7+ or Clang 4+, although GCC 9.4 and Clang 10 are the oldest tested
-versions and support for older compilers may be dropped) as well as Boost 1.69+
+versions and support for older compilers may be dropped) as well as Boost 1.70+
 (only headers are required), libdivide, and the Python development headers.
 At the moment only GNU/Linux and OS X get tested but other POSIX-like systems
 should work too. There are no plans to support Windows.

--- a/doc/migrate-3.rst
+++ b/doc/migrate-3.rst
@@ -130,7 +130,8 @@ Removal of deprecated functionality
 -----------------------------------
 The following functions were deprecated in version 2 and have been removed in version 3:
 
-- C++ stream constructors that specified a socket but not an :cpp:class:`!io_service`
+- C++ stream constructors that specified a socket but not an
+  :cpp:class:`!io_context`
   (they could not be supported with Boost 1.70 onwards).
 - Stream constructors that took both an existing (but unconnected) socket and a
   buffer size or a port to bind to. The caller should instead bind the socket

--- a/doc/tutorial/tut-2-send.rst
+++ b/doc/tutorial/tut-2-send.rst
@@ -99,7 +99,7 @@ tutorial we'll just hardcode an address (the local machine) and port number.
     :dedent: 0
 
         boost::asio::ip::udp::endpoint endpoint(
-            boost::asio::ip::address::from_string("127.0.0.1"),
+            boost::asio::ip::make_address("127.0.0.1"),
             8888
         );
         spead2::send::udp_stream stream(thread_pool, {endpoint}, config);

--- a/doc/tutorial/tut-4-send-perf.rst
+++ b/doc/tutorial/tut-4-send-perf.rst
@@ -156,7 +156,7 @@ heaps a command-line option too, and increase the default.
         }
         ...
         boost::asio::ip::udp::endpoint endpoint(
-            boost::asio::ip::address::from_string(argv[optind]),
+            boost::asio::ip::make_address(argv[optind]),
             std::stoi(argv[optind + 1])
         );
         ...

--- a/examples/gpudirect_example.cu
+++ b/examples/gpudirect_example.cu
@@ -1,4 +1,4 @@
-/* Copyright 2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -101,9 +101,9 @@ int main(int argc, const char * const *argv)
     spead2::send::udp_ibv_config ibv_config;
     ibv_config.add_endpoint(
         boost::asio::ip::udp::endpoint(
-            boost::asio::ip::address::from_string("239.255.88.88"),
+            boost::asio::ip::make_address("239.255.88.88"),
             8888));
-    ibv_config.set_interface_address(boost::asio::ip::address::from_string(argv[1]));
+    ibv_config.set_interface_address(boost::asio::ip::make_address(argv[1]));
     ibv_config.set_ttl(4);  // should be enough for most networks
     // The nvidia-peermem kernel module recognises that dout is a device pointer
     ibv_config.add_memory_region(dout, size);

--- a/examples/tutorial/tut_10_send_reuse_heaps.cpp
+++ b/examples/tutorial/tut_10_send_reuse_heaps.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023-2024 National Research Foundation (SARAO)
+/* Copyright 2023-2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -93,7 +93,7 @@ int main(int argc, char * const argv[])
     if (packet_size)
         config.set_max_packet_size(packet_size.value());
     boost::asio::ip::udp::endpoint endpoint(
-        boost::asio::ip::address::from_string(argv[optind]),
+        boost::asio::ip::make_address(argv[optind]),
         std::stoi(argv[optind + 1])
     );
     spead2::send::udp_stream stream(thread_pool, {endpoint}, config);

--- a/examples/tutorial/tut_11_send_batch_heaps.cpp
+++ b/examples/tutorial/tut_11_send_batch_heaps.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023-2024 National Research Foundation (SARAO)
+/* Copyright 2023-2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -100,7 +100,7 @@ int main(int argc, char * const argv[])
     if (packet_size)
         config.set_max_packet_size(packet_size.value());
     boost::asio::ip::udp::endpoint endpoint(
-        boost::asio::ip::address::from_string(argv[optind]),
+        boost::asio::ip::make_address(argv[optind]),
         std::stoi(argv[optind + 1])
     );
     spead2::send::udp_stream stream(thread_pool, {endpoint}, config);

--- a/examples/tutorial/tut_2_send.cpp
+++ b/examples/tutorial/tut_2_send.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 National Research Foundation (SARAO)
+/* Copyright 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -33,7 +33,7 @@ int main()
     spead2::send::stream_config config;
     config.set_rate(100e6);
     boost::asio::ip::udp::endpoint endpoint(
-        boost::asio::ip::address::from_string("127.0.0.1"),
+        boost::asio::ip::make_address("127.0.0.1"),
         8888
     );
     spead2::send::udp_stream stream(thread_pool, {endpoint}, config);

--- a/examples/tutorial/tut_4_send_perf.cpp
+++ b/examples/tutorial/tut_4_send_perf.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023-2024 National Research Foundation (SARAO)
+/* Copyright 2023-2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -62,7 +62,7 @@ int main(int argc, char * const argv[])
     spead2::send::stream_config config;
     config.set_rate(0.0);
     boost::asio::ip::udp::endpoint endpoint(
-        boost::asio::ip::address::from_string(argv[optind]),
+        boost::asio::ip::make_address(argv[optind]),
         std::stoi(argv[optind + 1])
     );
     spead2::send::udp_stream stream(thread_pool, {endpoint}, config);

--- a/examples/tutorial/tut_5_send_pipeline.cpp
+++ b/examples/tutorial/tut_5_send_pipeline.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023-2024 National Research Foundation (SARAO)
+/* Copyright 2023-2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -71,7 +71,7 @@ int main(int argc, char * const argv[])
     config.set_rate(0.0);
     config.set_max_heaps(2);
     boost::asio::ip::udp::endpoint endpoint(
-        boost::asio::ip::address::from_string(argv[optind]),
+        boost::asio::ip::make_address(argv[optind]),
         std::stoi(argv[optind + 1])
     );
     spead2::send::udp_stream stream(thread_pool, {endpoint}, config);

--- a/examples/tutorial/tut_6_send_pktsize.cpp
+++ b/examples/tutorial/tut_6_send_pktsize.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023-2024 National Research Foundation (SARAO)
+/* Copyright 2023-2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -78,7 +78,7 @@ int main(int argc, char * const argv[])
     if (packet_size)
         config.set_max_packet_size(packet_size.value());
     boost::asio::ip::udp::endpoint endpoint(
-        boost::asio::ip::address::from_string(argv[optind]),
+        boost::asio::ip::make_address(argv[optind]),
         std::stoi(argv[optind + 1])
     );
     spead2::send::udp_stream stream(thread_pool, {endpoint}, config);

--- a/examples/tutorial/tut_8_send_reuse_memory.cpp
+++ b/examples/tutorial/tut_8_send_reuse_memory.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023-2024 National Research Foundation (SARAO)
+/* Copyright 2023-2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -91,7 +91,7 @@ int main(int argc, char * const argv[])
     if (packet_size)
         config.set_max_packet_size(packet_size.value());
     boost::asio::ip::udp::endpoint endpoint(
-        boost::asio::ip::address::from_string(argv[optind]),
+        boost::asio::ip::make_address(argv[optind]),
         std::stoi(argv[optind + 1])
     );
     spead2::send::udp_stream stream(thread_pool, {endpoint}, config);

--- a/include/spead2/common_ibv.h
+++ b/include/spead2/common_ibv.h
@@ -1,4 +1,4 @@
-/* Copyright 2016-2020 National Research Foundation (SARAO)
+/* Copyright 2016-2020, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -182,7 +182,7 @@ public:
     explicit ibv_comp_channel_t(const rdma_cm_id_t &cm_id);
 
     /// Create a file descriptor that is ready to read when the completion channel has events
-    boost::asio::posix::stream_descriptor wrap(boost::asio::io_service &io_service) const;
+    boost::asio::posix::stream_descriptor wrap(boost::asio::io_context &io_context) const;
     /// Get an event, if one is available
     bool get_event(ibv_cq **cq, void **context);
 };

--- a/include/spead2/common_memory_pool.h
+++ b/include/spead2/common_memory_pool.h
@@ -1,4 +1,4 @@
-/* Copyright 2015-2017, 2021, 2023 National Research Foundation (SARAO)
+/* Copyright 2015-2017, 2021, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -56,7 +56,7 @@ class memory_pool : public memory_allocator
     friend class detail::memory_pool_deleter;
 
 private:
-    std::optional<io_service_ref> io_service;
+    std::optional<io_context_ref> io_context;
     const std::size_t lower, upper, max_free, initial, low_water;
     const std::shared_ptr<memory_allocator> base_allocator;
     mutable std::mutex mutex;
@@ -74,7 +74,7 @@ private:
     static void refill(std::size_t upper, std::shared_ptr<memory_allocator> allocator,
                        std::weak_ptr<memory_pool> self_weak);
 
-    memory_pool(std::optional<io_service_ref> io_service,
+    memory_pool(std::optional<io_context_ref> io_context,
                 std::size_t lower,
                 std::size_t upper,
                 std::size_t max_free,
@@ -87,7 +87,7 @@ public:
     memory_pool();
     memory_pool(std::size_t lower, std::size_t upper, std::size_t max_free, std::size_t initial,
                 std::shared_ptr<memory_allocator> allocator = nullptr);
-    memory_pool(io_service_ref io_service, std::size_t lower, std::size_t upper, std::size_t max_free, std::size_t initial, std::size_t low_water,
+    memory_pool(io_context_ref io_context, std::size_t lower, std::size_t upper, std::size_t max_free, std::size_t initial, std::size_t low_water,
                 std::shared_ptr<memory_allocator> allocator = nullptr);
     bool get_warn_on_empty() const;
     void set_warn_on_empty(bool warn);

--- a/include/spead2/common_semaphore.h
+++ b/include/spead2/common_semaphore.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 National Research Foundation (SARAO)
+/* Copyright 2015, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -142,7 +142,7 @@ public:
 };
 
 /// Duplicate a file descriptor and wrap it in boost::asio
-boost::asio::posix::stream_descriptor wrap_fd(boost::asio::io_service &io_service, int fd);
+boost::asio::posix::stream_descriptor wrap_fd(boost::asio::io_context &io_context, int fd);
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/include/spead2/common_socket.h
+++ b/include/spead2/common_socket.h
@@ -55,39 +55,37 @@ void set_socket_recv_buffer_size(SocketType &socket, std::size_t buffer_size);
 /**
  * Get an object suitable for constructing another socket with the same IO
  * context. The return type depends on the Boost version. This is necessary
- * because Boost 1.70 removed @c basic_socket::get_io_service (as well as
- * @c basic_socket::get_io_context).
+ * because Boost 1.70 removed @c basic_socket::get_io_context.
  */
 template<typename SocketType>
-static inline typename SocketType::executor_type get_socket_io_service(SocketType &socket)
+static inline typename SocketType::executor_type get_socket_executor(SocketType &socket)
 {
     return socket.get_executor();
 }
 #else
 template<typename SocketType>
-static inline boost::asio::io_service &get_socket_io_service(SocketType &socket)
+static inline boost::asio::io_context &get_socket_executor(SocketType &socket)
 {
-    return socket.get_io_service();
+    return socket.get_io_context();
 }
 #endif
 
 /**
  * Determine whether a socket is using a particular IO context. This is necessary
- * because Boost 1.70 removed @c basic_socket::get_io_service (as well as
- * @c basic_socket::get_io_context).
+ * because Boost 1.70 removed @c basic_socket::get_io_context.
  */
 template<typename SocketType>
-static inline bool socket_uses_io_service(SocketType &socket, boost::asio::io_service &io_service)
+static inline bool socket_uses_io_context(SocketType &socket, boost::asio::io_context &io_context)
 {
 #if BOOST_VERSION >= 107600 && BOOST_VERSION < 107700
     // Workaround for https://github.com/chriskohlhoff/asio/issues/853
-    typedef boost::asio::io_service::executor_type executor_type;
+    typedef boost::asio::io_context::executor_type executor_type;
     return socket.get_executor().target_type() == typeid(executor_type)
-          && *socket.get_executor().template target<executor_type>() == io_service.get_executor();
+          && *socket.get_executor().template target<executor_type>() == io_context.get_executor();
 #elif BOOST_VERSION >= 107000
-    return socket.get_executor() == io_service.get_executor();
+    return socket.get_executor() == io_context.get_executor();
 #else
-    return &socket.get_io_service() == &io_service;
+    return &socket.get_io_context() == &io_context;
 #endif
 }
 

--- a/include/spead2/common_socket.h
+++ b/include/spead2/common_socket.h
@@ -51,25 +51,6 @@ void set_socket_send_buffer_size(SocketType &socket, std::size_t buffer_size);
 template<typename SocketType>
 void set_socket_recv_buffer_size(SocketType &socket, std::size_t buffer_size);
 
-#if BOOST_VERSION >= 107000
-/**
- * Get an object suitable for constructing another socket with the same IO
- * context. The return type depends on the Boost version. This is necessary
- * because Boost 1.70 removed @c basic_socket::get_io_context.
- */
-template<typename SocketType>
-static inline typename SocketType::executor_type get_socket_executor(SocketType &socket)
-{
-    return socket.get_executor();
-}
-#else
-template<typename SocketType>
-static inline boost::asio::io_context &get_socket_executor(SocketType &socket)
-{
-    return socket.get_io_context();
-}
-#endif
-
 /**
  * Determine whether a socket is using a particular IO context. This is necessary
  * because Boost 1.70 removed @c basic_socket::get_io_context.
@@ -82,10 +63,8 @@ static inline bool socket_uses_io_context(SocketType &socket, boost::asio::io_co
     typedef boost::asio::io_context::executor_type executor_type;
     return socket.get_executor().target_type() == typeid(executor_type)
           && *socket.get_executor().template target<executor_type>() == io_context.get_executor();
-#elif BOOST_VERSION >= 107000
-    return socket.get_executor() == io_context.get_executor();
 #else
-    return &socket.get_io_context() == &io_context;
+    return socket.get_executor() == io_context.get_executor();
 #endif
 }
 

--- a/include/spead2/common_thread_pool.h
+++ b/include/spead2/common_thread_pool.h
@@ -42,7 +42,7 @@ class thread_pool
 private:
     boost::asio::io_context io_context;
     /// Prevents the io_context terminating automatically
-    boost::asio::io_context::work work;
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work_guard;
     /**
      * Futures that becomes ready when a worker thread completes. It
      * is connected to an async task.

--- a/include/spead2/common_thread_pool.h
+++ b/include/spead2/common_thread_pool.h
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2023 National Research Foundation (SARAO)
+/* Copyright 2015, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -33,16 +33,16 @@ namespace spead2
 {
 
 /**
- * Combination of a @c boost::asio::io_service with a set of threads to handle
+ * Combination of a @c boost::asio::io_context with a set of threads to handle
  * the callbacks. The threads are created by the constructor and shut down
  * and joined in the destructor.
  */
 class thread_pool
 {
 private:
-    boost::asio::io_service io_service;
-    /// Prevents the io_service terminating automatically
-    boost::asio::io_service::work work;
+    boost::asio::io_context io_context;
+    /// Prevents the io_context terminating automatically
+    boost::asio::io_context::work work;
     /**
      * Futures that becomes ready when a worker thread completes. It
      * is connected to an async task.
@@ -60,8 +60,11 @@ public:
     thread_pool(int num_threads, const std::vector<int> &affinity);
     ~thread_pool();
 
-    /// Retrieve the embedded io_service
-    boost::asio::io_service &get_io_service() { return io_service; }
+    /// Retrieve the embedded io_context
+    boost::asio::io_context &get_io_context() { return io_context; }
+    /// Retrieve the embedded io_context (deprecated alias)
+    [[deprecated("use get_io_context")]]
+    boost::asio::io_context &get_io_service() { return io_context; }
 
     /// Shut down the thread pool
     void stop();
@@ -72,38 +75,38 @@ public:
 };
 
 /**
- * A helper class that holds a reference to a @c boost::asio::io_service, and
+ * A helper class that holds a reference to a @c boost::asio::io_context, and
  * optionally a shared pointer to a thread_pool. It is normally not explicitly
- * constructed, but other classes that need an @c io_service take it as an
- * argument and store it so that they can accept any of @c io_service, @c
+ * constructed, but other classes that need an @c io_context take it as an
+ * argument and store it so that they can accept any of @c io_context, @c
  * thread_pool or @c std::shared_ptr<thread_pool>, and in the last case they
  * hold on to the reference.
  */
-class io_service_ref
+class io_context_ref
 {
 private:
     std::shared_ptr<thread_pool> thread_pool_holder;
-    boost::asio::io_service &io_service;
+    boost::asio::io_context &io_context;
 
     static void check_non_null(thread_pool *ptr);
 
 public:
-    /// Construct from a reference to an @c io_service
-    io_service_ref(boost::asio::io_service &);
+    /// Construct from a reference to an @c io_context
+    io_context_ref(boost::asio::io_context &);
     /// Construct from a reference to a @ref thread_pool
-    io_service_ref(thread_pool &);
+    io_context_ref(thread_pool &);
     /**
      * Construct from a shared pointer to a @ref thread_pool. This is templated
      * so that it will also accept a shared pointer to a subclass of @ref
      * thread_pool.
      */
     template<typename T, typename SFINAE = std::enable_if_t<std::is_convertible_v<T *, thread_pool *>>>
-    io_service_ref(std::shared_ptr<T>);
+    io_context_ref(std::shared_ptr<T>);
 
-    /// Return the referenced @c io_service.
-    boost::asio::io_service &operator*() const;
-    /// Return a pointer to the referenced @c io_service.
-    boost::asio::io_service *operator->() const;
+    /// Return the referenced @c io_context.
+    boost::asio::io_context &operator*() const;
+    /// Return a pointer to the referenced @c io_context.
+    boost::asio::io_context *operator->() const;
     /// Return the shared pointer to the @ref thread_pool, if constructed from one.
     std::shared_ptr<thread_pool> get_shared_thread_pool() const &;
     /**
@@ -115,11 +118,13 @@ public:
 };
 
 template<typename T, typename SFINAE>
-io_service_ref::io_service_ref(std::shared_ptr<T> tpool)
+io_context_ref::io_context_ref(std::shared_ptr<T> tpool)
     : thread_pool_holder((check_non_null(tpool.get()), std::move(tpool))),
-    io_service(thread_pool_holder->get_io_service())
+    io_context(thread_pool_holder->get_io_context())
 {
 }
+
+using io_service_ref [[deprecated("use io_context_ref instead")]] = io_context_ref;
 
 } // namespace spead2
 

--- a/include/spead2/py_common.h
+++ b/include/spead2/py_common.h
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2017, 2020-2021, 2023 National Research Foundation (SARAO)
+/* Copyright 2015, 2017, 2020-2021, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -88,7 +88,7 @@ public:
     socket_wrapper(typename SocketType::protocol_type protocol, int fd)
         : protocol(protocol), fd(fd) {}
 
-    SocketType copy(boost::asio::io_service &io_service) const
+    SocketType copy(boost::asio::io_context &io_context) const
     {
         int fd2 = ::dup(fd);
         if (fd2 == -1)
@@ -96,7 +96,7 @@ public:
             PyErr_SetFromErrno(PyExc_OSError);
             throw pybind11::error_already_set();
         }
-        return SocketType(io_service, protocol, fd2);
+        return SocketType(io_context, protocol, fd2);
     }
 };
 
@@ -105,7 +105,7 @@ extern template class socket_wrapper<boost::asio::ip::tcp::socket>;
 extern template class socket_wrapper<boost::asio::ip::tcp::acceptor>;
 
 boost::asio::ip::address make_address_no_release(
-    boost::asio::io_service &io_service, const std::string &hostname,
+    boost::asio::io_context &io_context, const std::string &hostname,
     boost::asio::ip::resolver_query_base::flags flags);
 
 namespace detail

--- a/include/spead2/recv_chunk_stream.h
+++ b/include/spead2/recv_chunk_stream.h
@@ -1,4 +1,4 @@
-/* Copyright 2021-2023 National Research Foundation (SARAO)
+/* Copyright 2021-2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -565,7 +565,7 @@ public:
      *   - <tt>rejected_heaps</tt>: number of heaps for which the placement function returned
      *     a negative chunk ID.
      *
-     * @param io_service       I/O service (also used by the readers).
+     * @param io_context       I/O context (also used by the readers).
      * @param config           Basic stream configuration
      * @param chunk_config     Configuration for chunking
      *
@@ -573,7 +573,7 @@ public:
      * have not been set.
      */
     chunk_stream(
-        io_service_ref io_service,
+        io_context_ref io_context,
         const stream_config &config,
         const chunk_stream_config &chunk_config);
 
@@ -669,7 +669,7 @@ public:
      * callbacks.
      */
     chunk_ring_stream(
-        io_service_ref io_service,
+        io_context_ref io_context,
         const stream_config &config,
         const chunk_stream_config &chunk_config,
         std::shared_ptr<DataRingbuffer> data_ring,
@@ -887,14 +887,14 @@ chunk_ready_function chunk_ring_pair<DataRingbuffer, FreeRingbuffer>::make_ready
 
 template<typename DataRingbuffer, typename FreeRingbuffer>
 chunk_ring_stream<DataRingbuffer, FreeRingbuffer>::chunk_ring_stream(
-        io_service_ref io_service,
+        io_context_ref io_context,
         const stream_config &config,
         const chunk_stream_config &chunk_config,
         std::shared_ptr<DataRingbuffer> data_ring,
         std::shared_ptr<FreeRingbuffer> free_ring)
     : detail::chunk_ring_pair<DataRingbuffer, FreeRingbuffer>(std::move(data_ring), std::move(free_ring)),
     chunk_stream(
-        io_service,
+        io_context,
         config,
         adjust_chunk_config(chunk_config, *this))
 {

--- a/include/spead2/recv_chunk_stream_group.h
+++ b/include/spead2/recv_chunk_stream_group.h
@@ -1,4 +1,4 @@
-/* Copyright 2023 National Research Foundation (SARAO)
+/* Copyright 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -236,7 +236,7 @@ public:
 
     /// Add a new stream
     chunk_stream_group_member &emplace_back(
-        io_service_ref io_service,
+        io_context_ref io_context,
         const stream_config &config,
         const chunk_stream_config &chunk_config);
 
@@ -296,7 +296,7 @@ private:
      * Flush all chunks with an ID strictly less than @a chunk_id.
      *
      * This function returns immediately, and the work is done later on the
-     * io_service. It is safe to call from any thread.
+     * io_context. It is safe to call from any thread.
      */
     void async_flush_until(std::uint64_t chunk_id);
 
@@ -313,7 +313,7 @@ protected:
      *
      * @param group            Group to which this stream belongs
      * @param group_index      Position of this stream within the group
-     * @param io_service       I/O service (also used by the readers).
+     * @param io_context       I/O context (also used by the readers).
      * @param config           Basic stream configuration
      * @param chunk_config     Configuration for chunking
      *
@@ -323,7 +323,7 @@ protected:
     chunk_stream_group_member(
         chunk_stream_group &group,
         std::size_t group_index,
-        io_service_ref io_service,
+        io_context_ref io_context,
         const stream_config &config,
         const chunk_stream_config &chunk_config);
 

--- a/include/spead2/recv_ring_stream.h
+++ b/include/spead2/recv_ring_stream.h
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2019-2021, 2023 National Research Foundation (SARAO)
+/* Copyright 2015, 2019-2021, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -65,7 +65,7 @@ private:
 
 public:
     ring_stream_base(
-        io_service_ref io_service,
+        io_context_ref io_context,
         const stream_config &config = stream_config(),
         const ring_stream_config &ring_config = ring_stream_config());
 
@@ -96,12 +96,12 @@ public:
     /**
      * Constructor.
      *
-     * @param io_service       I/O service (also used by the readers).
+     * @param io_context       I/O context (also used by the readers).
      * @param config           Stream configuration
      * @param ring_config      Ringbuffer configuration
      */
     explicit ring_stream(
-        io_service_ref io_service,
+        io_context_ref io_context,
         const stream_config &config = stream_config(),
         const ring_stream_config &ring_config = ring_stream_config());
 
@@ -174,10 +174,10 @@ public:
 
 template<typename Ringbuffer>
 ring_stream<Ringbuffer>::ring_stream(
-    io_service_ref io_service,
+    io_context_ref io_context,
     const stream_config &config,
     const ring_stream_config &ring_config)
-    : ring_stream_base(std::move(io_service), config, ring_config),
+    : ring_stream_base(std::move(io_context), config, ring_config),
     ready_heaps(ring_config.get_heaps())
 {
 }

--- a/include/spead2/recv_stream.h
+++ b/include/spead2/recv_stream.h
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2017-2021, 2023 National Research Foundation (SARAO)
+/* Copyright 2015, 2017-2021, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free

--- a/include/spead2/recv_stream.h
+++ b/include/spead2/recv_stream.h
@@ -46,7 +46,7 @@ namespace spead2
 {
 
 class thread_pool;
-class io_service_ref;
+class io_context_ref;
 
 namespace recv
 {
@@ -809,7 +809,7 @@ public:
 class reader
 {
 private:
-    boost::asio::io_service &io_service;
+    boost::asio::io_context &io_context;
     std::shared_ptr<stream_base::shared_state> owner;  ///< Access to owning stream
 
 protected:
@@ -907,8 +907,11 @@ public:
     explicit reader(stream &owner);
     virtual ~reader() = default;
 
-    /// Retrieve the @c io_service corresponding to the owner
-    boost::asio::io_service &get_io_service() { return io_service; }
+    /// Retrieve the @c io_context corresponding to the owner
+    boost::asio::io_context &get_io_context() { return io_context; }
+    /// Retrieve the @c io_context corresponding to the owner (deprecated)
+    [[deprecated("use get_io_context")]]
+    boost::asio::io_context &get_io_service() { return io_context; }
 
     /**
      * Whether the reader risks losing data if it is not given a chance to
@@ -961,8 +964,8 @@ private:
     /// Holder that just ensures that the thread pool doesn't vanish
     std::shared_ptr<thread_pool> thread_pool_holder;
 
-    /// I/O service used by the readers
-    boost::asio::io_service &io_service;
+    /// I/O context used by the readers
+    boost::asio::io_context &io_context;
 
     /// Protects mutable state (@ref readers, @ref stop_readers, @ref readers_started, @ref lossy).
     mutable std::mutex reader_mutex;
@@ -1003,28 +1006,30 @@ protected:
     using stream_base::post; // Make base class version visible, despite being overloaded
 
     /**
-     * Schedule a function to be called on the stream's io_service, with the
+     * Schedule a function to be called on the stream's io_context, with the
      * lock held. This is a fire-and-forget operation. If the stream is stopped
      * before the callback fires, the callback is silently dropped.
      */
     template<typename F>
     void post(F &&func)
     {
-        post(get_io_service(), std::forward<F>(func));
+        post(get_io_context(), std::forward<F>(func));
     }
 
 public:
     using stream_base::get_config;
     using stream_base::get_stats;
 
-    explicit stream(io_service_ref io_service, const stream_config &config = stream_config());
+    explicit stream(io_context_ref io_context, const stream_config &config = stream_config());
     virtual ~stream() override;
 
-    boost::asio::io_service &get_io_service() { return io_service; }
+    boost::asio::io_context &get_io_context() { return io_context; }
+    [[deprecated("use get_io_context")]]
+    boost::asio::io_context &get_io_service() { return io_context; }
 
     /**
      * Add a new reader by passing its constructor arguments, excluding
-     * the initial @a io_service and @a owner arguments.
+     * the initial @a io_context and @a owner arguments.
      */
     template<typename T, typename... Args>
     void emplace_reader(Args&&... args)
@@ -1056,7 +1061,7 @@ public:
     void start();
 
     /**
-     * Stop the stream. After this returns, the io_service may still have
+     * Stop the stream. After this returns, the io_context may still have
      * outstanding completion handlers, but they should be no-ops when they're
      * called.
      *

--- a/include/spead2/recv_udp.h
+++ b/include/spead2/recv_udp.h
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2020, 2023-2024 National Research Foundation (SARAO)
+/* Copyright 2015, 2020, 2023-2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -177,7 +177,7 @@ public:
      *
      * @param owner        Owning stream
      * @param socket       Existing socket which will be taken over. It must
-     *                     use the same I/O service as @a owner.
+     *                     use the same I/O context as @a owner.
      * @param max_size     Maximum packet size that will be accepted.
      */
     udp_reader(

--- a/include/spead2/recv_udp_ibv.h
+++ b/include/spead2/recv_udp_ibv.h
@@ -1,4 +1,4 @@
-/* Copyright 2016, 2019-2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2016, 2019-2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -139,8 +139,8 @@ protected:
     /**
      * Retrieve packets from the completion queue and process them.
      *
-     * This is called from the io_service either when the completion channel
-     * is notified (non-polling mode) or by a post to the io_service (polling
+     * This is called from the io_context either when the completion channel
+     * is notified (non-polling mode) or by a post to the io_context (polling
      * mode).
      *
      * If @a consume_event is true, an event should be removed and consumed
@@ -239,7 +239,7 @@ void udp_ibv_reader_base<Derived>::enqueue_receive(handler_context ctx, bool nee
     {
         // Polling mode
         boost::asio::post(
-            get_io_service(),
+            get_io_context(),
             bind_handler(
                 std::move(ctx),
                 std::bind(&udp_ibv_reader_base<Derived>::packet_handler, this, _1, _2,

--- a/include/spead2/send_inproc.h
+++ b/include/spead2/send_inproc.h
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2018-2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -36,7 +36,7 @@ class inproc_stream : public stream
 public:
     /// Constructor
     inproc_stream(
-        io_service_ref io_service,
+        io_context_ref io_context,
         const std::vector<std::shared_ptr<inproc_queue>> &queues,
         const stream_config &config = stream_config());
 

--- a/include/spead2/send_stream.h
+++ b/include/spead2/send_stream.h
@@ -327,7 +327,7 @@ private:
                 unwind.abort();
                 lock.unlock();
                 log_warning("async_send_heap(s): dropping heap because substream index is out of range");
-                get_io_context().post(std::bind(std::move(handler), boost::asio::error::invalid_argument, 0));
+                boost::asio::post(get_io_context(), std::bind(std::move(handler), boost::asio::error::invalid_argument, 0));
                 return false;
             }
             item_pointer_t cnt_mask = (item_pointer_t(1) << h.get_flavour().get_heap_address_bits()) - 1;
@@ -337,7 +337,7 @@ private:
                 unwind.abort();
                 lock.unlock();
                 log_warning("async_send_heap(s): dropping heap because queue is full");
-                get_io_context().post(std::bind(std::move(handler), boost::asio::error::would_block, 0));
+                boost::asio::post(get_io_context(), std::bind(std::move(handler), boost::asio::error::would_block, 0));
                 return false;
             }
             if (cnt < 0)
@@ -349,7 +349,7 @@ private:
             {
                 lock.unlock();
                 log_warning("async_send_heap(s): dropping heap because cnt is out of range");
-                get_io_context().post(std::bind(std::move(handler), boost::asio::error::invalid_argument, 0));
+                boost::asio::post(get_io_context(), std::bind(std::move(handler), boost::asio::error::invalid_argument, 0));
                 return false;
             }
 
@@ -392,7 +392,7 @@ private:
         if (wakeup)
         {
             writer *w_ptr = w.get();
-            get_io_context().post([w_ptr]() {
+            boost::asio::post(get_io_context(), [w_ptr]() {
                 w_ptr->update_send_time_empty();
                 w_ptr->wakeup();
             });
@@ -534,7 +534,7 @@ public:
         if (first == last)
         {
             log_warning("Empty heap group");
-            get_io_context().post(std::bind(std::move(handler), boost::asio::error::invalid_argument, 0));
+            boost::asio::post(get_io_context(), std::bind(std::move(handler), boost::asio::error::invalid_argument, 0));
             return false;
         }
         return async_send_heaps_impl<unwinder, Iterator>(first, last, std::move(handler), mode);

--- a/include/spead2/send_stream.h
+++ b/include/spead2/send_stream.h
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2017, 2019-2020, 2023-2024 National Research Foundation (SARAO)
+/* Copyright 2015, 2017, 2019-2020, 2023-2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -327,7 +327,7 @@ private:
                 unwind.abort();
                 lock.unlock();
                 log_warning("async_send_heap(s): dropping heap because substream index is out of range");
-                get_io_service().post(std::bind(std::move(handler), boost::asio::error::invalid_argument, 0));
+                get_io_context().post(std::bind(std::move(handler), boost::asio::error::invalid_argument, 0));
                 return false;
             }
             item_pointer_t cnt_mask = (item_pointer_t(1) << h.get_flavour().get_heap_address_bits()) - 1;
@@ -337,7 +337,7 @@ private:
                 unwind.abort();
                 lock.unlock();
                 log_warning("async_send_heap(s): dropping heap because queue is full");
-                get_io_service().post(std::bind(std::move(handler), boost::asio::error::would_block, 0));
+                get_io_context().post(std::bind(std::move(handler), boost::asio::error::would_block, 0));
                 return false;
             }
             if (cnt < 0)
@@ -349,7 +349,7 @@ private:
             {
                 lock.unlock();
                 log_warning("async_send_heap(s): dropping heap because cnt is out of range");
-                get_io_service().post(std::bind(std::move(handler), boost::asio::error::invalid_argument, 0));
+                get_io_context().post(std::bind(std::move(handler), boost::asio::error::invalid_argument, 0));
                 return false;
             }
 
@@ -392,7 +392,7 @@ private:
         if (wakeup)
         {
             writer *w_ptr = w.get();
-            get_io_service().post([w_ptr]() {
+            get_io_context().post([w_ptr]() {
                 w_ptr->update_send_time_empty();
                 w_ptr->wakeup();
             });
@@ -407,8 +407,11 @@ protected:
     explicit stream(std::unique_ptr<writer> &&w);
 
 public:
-    /// Retrieve the io_service used for processing the stream
-    boost::asio::io_service &get_io_service() const;
+    /// Retrieve the io_context used for processing the stream
+    boost::asio::io_context &get_io_context() const;
+    /// Retrieve the io_context used for processing the stream (deprecated)
+    [[deprecated("use get_io_context")]]
+    boost::asio::io_context &get_io_service() const;
 
     /**
      * Modify the linear sequence used to generate heap cnts. The next heap
@@ -433,7 +436,7 @@ public:
      *
      * If this function returns @c false, the heap was rejected without
      * being added to the queue. The handler is called as soon as possible
-     * (from a thread running the io_service). If the heap was rejected due to
+     * (from a thread running the io_context). If the heap was rejected due to
      * lack of space, the error code is @c boost::asio::error::would_block.
      *
      * By default the heap cnt is chosen automatically (see @ref set_cnt_sequence).
@@ -503,7 +506,7 @@ public:
      *
      * If this function returns @c false, the heaps were rejected without
      * being added to the queue. The handler is called as soon as possible
-     * (from a thread running the io_service). If the heaps were rejected due to
+     * (from a thread running the io_context). If the heaps were rejected due to
      * lack of space, the error code is @c boost::asio::error::would_block.
      * It is an error to send an empty list of heaps.
      *
@@ -531,7 +534,7 @@ public:
         if (first == last)
         {
             log_warning("Empty heap group");
-            get_io_service().post(std::bind(std::move(handler), boost::asio::error::invalid_argument, 0));
+            get_io_context().post(std::bind(std::move(handler), boost::asio::error::invalid_argument, 0));
             return false;
         }
         return async_send_heaps_impl<unwinder, Iterator>(first, last, std::move(handler), mode);

--- a/include/spead2/send_streambuf.h
+++ b/include/spead2/send_streambuf.h
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2019-2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2015, 2019-2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -40,7 +40,7 @@ class streambuf_stream : public stream
 public:
     /// Constructor
     streambuf_stream(
-        io_service_ref io_service,
+        io_context_ref io_context,
         std::streambuf &streambuf,
         const stream_config &config = stream_config());
 };

--- a/include/spead2/send_tcp.h
+++ b/include/spead2/send_tcp.h
@@ -42,7 +42,7 @@ public:
      * @warning The callback may be called before the constructor returns. The
      * implementation of the callback needs to be prepared to handle this case.
      *
-     * @param io_service   I/O service for sending data
+     * @param io_context   I/O context for sending data
      * @param connect_handler  Callback when connection is established. It is called
      *                     with a @c boost::system::error_code to indicate whether
      *                     connection was successful.
@@ -55,7 +55,7 @@ public:
      *                            @endverbatim
      */
     tcp_stream(
-        io_service_ref io_service,
+        io_context_ref io_context,
         std::function<void(const boost::system::error_code &)> &&connect_handler,
         const std::vector<boost::asio::ip::tcp::endpoint> &endpoints,
         const stream_config &config = stream_config(),
@@ -66,7 +66,7 @@ public:
      * Constructor using an existing socket. The socket must be connected.
      */
     tcp_stream(
-        io_service_ref io_service,
+        io_context_ref io_context,
         boost::asio::ip::tcp::socket &&socket,
         const stream_config &config = stream_config());
 };

--- a/include/spead2/send_udp.h
+++ b/include/spead2/send_udp.h
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2019-2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2015, 2019-2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -45,7 +45,7 @@ private:
      * Constructor used to implement most other constructors.
      */
     udp_stream(
-        io_service_ref io_service,
+        io_context_ref io_context,
         boost::asio::ip::udp::socket &&socket,
         const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
         const stream_config &config,
@@ -62,7 +62,7 @@ public:
      * primarily intended for unicast as it does not provide all the options
      * that the multicast-specific constructors do.
      *
-     * @param io_service   I/O service for sending data
+     * @param io_context   I/O context for sending data
      * @param endpoints    Destination address and port for each substream
      * @param config       Stream configuration
      * @param buffer_size  Socket buffer size (0 for OS default)
@@ -72,19 +72,19 @@ public:
      *                            @endverbatim
      */
     udp_stream(
-        io_service_ref io_service,
+        io_context_ref io_context,
         const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
         const stream_config &config = stream_config(),
         std::size_t buffer_size = default_buffer_size,
         const boost::asio::ip::address &interface_address = boost::asio::ip::address());
 
     /**
-     * Constructor using an existing socket and an explicit io_service or
+     * Constructor using an existing socket and an explicit io_context or
      * thread pool. The socket must be open but not connected, and the
-     * io_service must match the socket's.
+     * io_context must match the socket's.
      */
     udp_stream(
-        io_service_ref io_service,
+        io_context_ref io_context,
         boost::asio::ip::udp::socket &&socket,
         const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
         const stream_config &config = stream_config());
@@ -92,7 +92,7 @@ public:
     /**
      * Constructor with multicast hop count.
      *
-     * @param io_service   I/O service for sending data
+     * @param io_context   I/O context for sending data
      * @param endpoints    Multicast group and port for each substream
      * @param config       Stream configuration
      * @param buffer_size  Socket buffer size (0 for OS default)
@@ -103,7 +103,7 @@ public:
      * @throws std::invalid_argument if @a endpoints is empty
      */
     udp_stream(
-        io_service_ref io_service,
+        io_context_ref io_context,
         const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
         const stream_config &config,
         std::size_t buffer_size,
@@ -113,7 +113,7 @@ public:
      * Constructor with multicast hop count and outgoing interface address
      * (IPv4 only).
      *
-     * @param io_service   I/O service for sending data
+     * @param io_context   I/O context for sending data
      * @param endpoints    Multicast group and port for each substream
      * @param config       Stream configuration
      * @param buffer_size  Socket buffer size (0 for OS default)
@@ -125,7 +125,7 @@ public:
      * @throws std::invalid_argument if @a interface_address is not an IPv4 address
      */
     udp_stream(
-        io_service_ref io_service,
+        io_context_ref io_context,
         const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
         const stream_config &config,
         std::size_t buffer_size,
@@ -136,7 +136,7 @@ public:
      * Constructor with multicast hop count and outgoing interface index
      * (IPv6 only).
      *
-     * @param io_service   I/O service for sending data
+     * @param io_context   I/O context for sending data
      * @param endpoints    Multicast group and port for each substream
      * @param config       Stream configuration
      * @param buffer_size  Socket buffer size (0 for OS default)
@@ -149,7 +149,7 @@ public:
      * @see if_nametoindex(3)
      */
     udp_stream(
-        io_service_ref io_service,
+        io_context_ref io_context,
         const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
         const stream_config &config,
         std::size_t buffer_size,

--- a/include/spead2/send_udp_ibv.h
+++ b/include/spead2/send_udp_ibv.h
@@ -1,4 +1,4 @@
-/* Copyright 2016, 2019-2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2016, 2019-2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -95,7 +95,7 @@ public:
     /**
      * Constructor.
      *
-     * @param io_service   I/O service for sending data
+     * @param io_context   I/O context for sending data
      * @param config       Common stream configuration
      * @param ibv_config   Class-specific stream configuration
      *
@@ -104,7 +104,7 @@ public:
      * @throws std::invalid_argument if memory regions overlap.
      */
     udp_ibv_stream(
-        io_service_ref io_service,
+        io_context_ref io_context,
         const stream_config &config,
         const udp_ibv_config &ibv_config);
 };

--- a/include/spead2/send_writer.h
+++ b/include/spead2/send_writer.h
@@ -1,4 +1,4 @@
-/* Copyright 2020, 2023-2024 National Research Foundation (SARAO)
+/* Copyright 2020, 2023-2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -72,7 +72,7 @@ public:
  * Each stream class will need to implement a subclass of @ref writer. At a
  * minimum, it will need to implement @ref wakeup and @ref get_num_substreams.
  *
- * A writer is intended to run on an io_service. It is *not* thread-safe, so
+ * A writer is intended to run on an io_context. It is *not* thread-safe, so
  * the subclass must ensure that only one handler runs at a time.
  *
  * The @ref wakeup handler should use @ref get_packet to try to retrieve
@@ -86,7 +86,7 @@ public:
  * It is not safe to call @ref wakeup (or @ref post_wakeup) immediately after
  * construction, because the associated stream is not yet known. If there is
  * initialisation that has the potential to interact with the stream
- * (including by posting a callback, which the io_service might immediately run
+ * (including by posting a callback, which the io_context might immediately run
  * on another thread), it should be done by overriding @ref start.
  */
 class writer
@@ -120,7 +120,7 @@ private:
 
     const stream_config config;    // TODO: probably doesn't need the whole thing
 
-    io_service_ref io_service;
+    io_context_ref io_context;
 
     /// Timer for sleeping for rate limiting
     timer_type timer;
@@ -227,13 +227,16 @@ protected:
     /// Schedule wakeup to be called immediately.
     void post_wakeup();
 
-    writer(io_service_ref io_service, const stream_config &config);
+    writer(io_context_ref io_context, const stream_config &config);
 
 public:
     virtual ~writer() = default;
 
-    /// Retrieve the io_service used for processing the stream
-    boost::asio::io_service &get_io_service() const { return *io_service; }
+    /// Retrieve the io_context used for processing the stream
+    boost::asio::io_context &get_io_context() const { return *io_context; }
+    /// Retrieve the io_context used for processing the stream (deprecated)
+    [[deprecated("use get_io_context")]]
+    boost::asio::io_context &get_io_service() const { return *io_context; }
 
     /// Number of substreams
     virtual std::size_t get_num_substreams() const = 0;

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 National Research Foundation (SARAO)
+# Copyright 2023-2025 National Research Foundation (SARAO)
 #
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free

--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ compiler = meson.get_compiler('cpp')
 py = import('python').find_installation(pure : false, modules : ['jinja2', 'pycparser', 'packaging'])
 
 # Required dependencies
-boost_dep = dependency('boost', version : '>=1.69')
+boost_dep = dependency('boost', version : '>=1.70')
 dl_dep = dependency('dl')
 thread_dep = dependency('threads')
 compiler.check_header('libdivide.h', required : true)

--- a/src/common_ibv.cpp
+++ b/src/common_ibv.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2020 National Research Foundation (SARAO)
+/* Copyright 2016-2020, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -261,10 +261,10 @@ ibv_comp_channel_t::ibv_comp_channel_t(const rdma_cm_id_t &cm_id)
 }
 
 boost::asio::posix::stream_descriptor ibv_comp_channel_t::wrap(
-    boost::asio::io_service &io_service) const
+    boost::asio::io_context &io_context) const
 {
     assert(get());
-    return wrap_fd(io_service, get()->fd);
+    return wrap_fd(io_context, get()->fd);
 }
 
 bool ibv_comp_channel_t::get_event(ibv_cq **cq, void **context)

--- a/src/common_memory_pool.cpp
+++ b/src/common_memory_pool.cpp
@@ -194,7 +194,7 @@ memory_pool::pointer memory_pool::allocate(std::size_t size, void *hint)
                 // C++ (or at least GCC) won't let me capture the members by value directly
                 const std::size_t upper = this->upper;
                 std::shared_ptr<memory_allocator> allocator = base_allocator;
-                (*io_context)->post([upper, allocator, weak] {
+                boost::asio::post(**io_context, [upper, allocator, weak] {
                     refill(upper, allocator, std::move(weak));
                 });
             }

--- a/src/common_semaphore.cpp
+++ b/src/common_semaphore.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015 National Research Foundation (SARAO)
+/* Copyright 2015, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -370,12 +370,12 @@ int semaphore_eventfd::get_fd() const
 
 #endif // SPEAD2_USE_EVENTFD
 
-boost::asio::posix::stream_descriptor wrap_fd(boost::asio::io_service &io_service, int fd)
+boost::asio::posix::stream_descriptor wrap_fd(boost::asio::io_context &io_context, int fd)
 {
     int fd2 = dup(fd);
     if (fd2 < 0)
         throw_errno("dup failed");
-    boost::asio::posix::stream_descriptor wrapper(io_service, fd2);
+    boost::asio::posix::stream_descriptor wrapper(io_context, fd2);
     wrapper.native_non_blocking(true);
     return wrapper;
 }

--- a/src/common_thread_pool.cpp
+++ b/src/common_thread_pool.cpp
@@ -59,7 +59,7 @@ static void run_io_context(boost::asio::io_context &io_context)
 }
 
 thread_pool::thread_pool(int num_threads)
-    : work(io_context)
+    : work_guard(boost::asio::make_work_guard(io_context))
 {
     if (num_threads < 1)
         throw std::invalid_argument("at least one thread is required");
@@ -71,7 +71,7 @@ thread_pool::thread_pool(int num_threads)
 }
 
 thread_pool::thread_pool(int num_threads, const std::vector<int> &affinity)
-    : work(io_context)
+    : work_guard(boost::asio::make_work_guard(io_context))
 {
     if (num_threads < 1)
         throw std::invalid_argument("at least one thread is required");

--- a/src/mcdump.cpp
+++ b/src/mcdump.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2016-2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -396,7 +396,7 @@ typedef std::function<chunking_scheme(const options &,
 class joiner
 {
 private:
-    boost::asio::io_service io_service;
+    boost::asio::io_context io_context;
     boost::asio::ip::udp::socket join_socket;
 
 public:
@@ -406,7 +406,7 @@ public:
 
 joiner::joiner(const boost::asio::ip::address_v4 &interface_address,
                const std::vector<boost::asio::ip::udp::endpoint> &endpoints)
-    : join_socket(io_service, endpoints[0].protocol())
+    : join_socket(io_context, endpoints[0].protocol())
 {
     join_socket.set_option(boost::asio::socket_base::reuse_address(true));
     for (const auto &endpoint : endpoints)

--- a/src/mcdump.cpp
+++ b/src/mcdump.cpp
@@ -578,7 +578,7 @@ static boost::asio::ip::address_v4 get_interface_address(const options &opts)
     boost::asio::ip::address_v4 interface_address;
     try
     {
-        interface_address = boost::asio::ip::address_v4::from_string(opts.interface);
+        interface_address = boost::asio::ip::make_address_v4(opts.interface);
     }
     catch (std::exception &)
     {
@@ -633,7 +633,7 @@ static boost::asio::ip::udp::endpoint make_endpoint(const std::string &s)
     }
     try
     {
-        boost::asio::ip::address_v4 addr = boost::asio::ip::address_v4::from_string(s.substr(0, pos));
+        boost::asio::ip::address_v4 addr = boost::asio::ip::make_address_v4(s.substr(0, pos));
         std::uint16_t port = boost::lexical_cast<std::uint16_t>(s.substr(pos + 1));
         return boost::asio::ip::udp::endpoint(addr, port);
     }

--- a/src/py_common.cpp
+++ b/src/py_common.cpp
@@ -101,8 +101,7 @@ boost::asio::ip::address make_address_no_release(
         return boost::asio::ip::address();
     using boost::asio::ip::udp;
     udp::resolver resolver(io_context);
-    udp::resolver::query query(hostname, "", flags);
-    return resolver.resolve(query)->endpoint().address();
+    return resolver.resolve(hostname, "", flags)->endpoint().address();
 }
 
 void deprecation_warning(const char *msg)
@@ -373,7 +372,7 @@ void register_module(py::module m)
                 py::gil_scoped_release release;
                 boost::asio::io_context io_context;
                 return ibv_context_t(make_address_no_release(
-                    io_context, interface_address, boost::asio::ip::udp::resolver::query::passive));
+                    io_context, interface_address, boost::asio::ip::udp::resolver::passive));
             }), "interface"_a)
         .def("reset", [](ibv_context_t &self) { self.reset(); })
     ;

--- a/src/py_common.cpp
+++ b/src/py_common.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2017, 2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2015, 2017, 2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -94,13 +94,13 @@ template class socket_wrapper<boost::asio::ip::tcp::socket>;
 template class socket_wrapper<boost::asio::ip::tcp::acceptor>;
 
 boost::asio::ip::address make_address_no_release(
-    boost::asio::io_service &io_service, const std::string &hostname,
+    boost::asio::io_context &io_context, const std::string &hostname,
     boost::asio::ip::resolver_query_base::flags flags)
 {
     if (hostname == "")
         return boost::asio::ip::address();
     using boost::asio::ip::udp;
-    udp::resolver resolver(io_service);
+    udp::resolver resolver(io_context);
     udp::resolver::query query(hostname, "", flags);
     return resolver.resolve(query)->endpoint().address();
 }
@@ -371,9 +371,9 @@ void register_module(py::module m)
         .def(py::init([](const std::string &interface_address)
             {
                 py::gil_scoped_release release;
-                boost::asio::io_service io_service;
+                boost::asio::io_context io_context;
                 return ibv_context_t(make_address_no_release(
-                    io_service, interface_address, boost::asio::ip::udp::resolver::query::passive));
+                    io_context, interface_address, boost::asio::ip::udp::resolver::query::passive));
             }), "interface"_a)
         .def("reset", [](ibv_context_t &self) { self.reset(); })
     ;

--- a/src/py_common.cpp
+++ b/src/py_common.cpp
@@ -101,7 +101,7 @@ boost::asio::ip::address make_address_no_release(
         return boost::asio::ip::address();
     using boost::asio::ip::udp;
     udp::resolver resolver(io_context);
-    return resolver.resolve(hostname, "", flags)->endpoint().address();
+    return resolver.resolve(hostname, "", flags).begin()->endpoint().address();
 }
 
 void deprecation_warning(const char *msg)

--- a/src/py_recv.cpp
+++ b/src/py_recv.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2017, 2020-2023 National Research Foundation (SARAO)
+/* Copyright 2015, 2017, 2020-2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -120,7 +120,7 @@ public:
 
 static boost::asio::ip::address make_address(stream &s, const std::string &hostname)
 {
-    return make_address_no_release(s.get_io_service(), hostname,
+    return make_address_no_release(s.get_io_context(), hostname,
                                    boost::asio::ip::udp::resolver::query::passive);
 }
 
@@ -155,7 +155,7 @@ static void add_udp_reader_socket(
     const socket_wrapper<boost::asio::ip::udp::socket> &socket,
     std::size_t max_size = udp_reader::default_max_size)
 {
-    auto asio_socket = socket.copy(s.get_io_service());
+    auto asio_socket = socket.copy(s.get_io_context());
     py::gil_scoped_release gil;
     s.emplace_reader<udp_reader>(std::move(asio_socket), max_size);
 }
@@ -203,7 +203,7 @@ static void add_tcp_reader_socket(
     const socket_wrapper<boost::asio::ip::tcp::acceptor> &acceptor,
     std::size_t max_size)
 {
-    auto asio_socket = acceptor.copy(s.get_io_service());
+    auto asio_socket = acceptor.copy(s.get_io_context());
     py::gil_scoped_release gil;
     s.emplace_reader<tcp_reader>(std::move(asio_socket), max_size);
 }
@@ -286,11 +286,11 @@ private:
 
 public:
     ring_stream_wrapper(
-        io_service_ref io_service,
+        io_context_ref io_context,
         const stream_config &config = stream_config(),
         const ring_stream_config_wrapper &ring_config = ring_stream_config_wrapper())
         : ring_stream<ringbuffer<live_heap, semaphore_fd, semaphore>>(
-            std::move(io_service), config, ring_config),
+            std::move(io_context), config, ring_config),
         incomplete_keep_payload_ranges(ring_config.get_incomplete_keep_payload_ranges())
     {}
 

--- a/src/py_recv.cpp
+++ b/src/py_recv.cpp
@@ -121,7 +121,7 @@ public:
 static boost::asio::ip::address make_address(stream &s, const std::string &hostname)
 {
     return make_address_no_release(s.get_io_context(), hostname,
-                                   boost::asio::ip::udp::resolver::query::passive);
+                                   boost::asio::ip::udp::resolver::passive);
 }
 
 template<typename Protocol>

--- a/src/recv_chunk_stream.cpp
+++ b/src/recv_chunk_stream.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2021-2023 National Research Foundation (SARAO)
+/* Copyright 2021-2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -247,11 +247,11 @@ template class chunk_stream_allocator<chunk_manager_simple>;
 } // namespace detail
 
 chunk_stream::chunk_stream(
-    io_service_ref io_service,
+    io_context_ref io_context,
     const stream_config &config,
     const chunk_stream_config &chunk_config)
     : chunk_stream_state(config, chunk_config, detail::chunk_manager_simple(chunk_config)),
-    stream(std::move(io_service), adjust_config(config))
+    stream(std::move(io_context), adjust_config(config))
 {
 }
 

--- a/src/recv_chunk_stream_group.cpp
+++ b/src/recv_chunk_stream_group.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 National Research Foundation (SARAO)
+/* Copyright 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -123,11 +123,11 @@ chunk_stream_group::const_iterator chunk_stream_group::cend() const noexcept
 }
 
 chunk_stream_group_member &chunk_stream_group::emplace_back(
-    io_service_ref io_service,
+    io_context_ref io_context,
     const stream_config &config,
     const chunk_stream_config &chunk_config)
 {
-    return emplace_back<chunk_stream_group_member>(std::move(io_service), config, chunk_config);
+    return emplace_back<chunk_stream_group_member>(std::move(io_context), config, chunk_config);
 }
 
 void chunk_stream_group::stop()
@@ -232,11 +232,11 @@ void chunk_stream_group::stream_head_updated(chunk_stream_group_member &s, std::
 chunk_stream_group_member::chunk_stream_group_member(
     chunk_stream_group &group,
     std::size_t group_index,
-    io_service_ref io_service,
+    io_context_ref io_context,
     const stream_config &config,
     const chunk_stream_config &chunk_config)
     : chunk_stream_state(config, chunk_config, detail::chunk_manager_group(group)),
-    stream(std::move(io_service), adjust_config(config)),
+    stream(std::move(io_context), adjust_config(config)),
     group(group), group_index(group_index)
 {
     if (chunk_config.get_max_chunks() > group.config.get_max_chunks())

--- a/src/recv_inproc.cpp
+++ b/src/recv_inproc.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2019, 2023 National Research Foundation (SARAO)
+/* Copyright 2018-2019, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -34,7 +34,7 @@ inproc_reader::inproc_reader(
     std::shared_ptr<inproc_queue> queue)
     : reader(owner),
     queue(std::move(queue)),
-    data_sem_wrapper(wrap_fd(owner.get_io_service(),
+    data_sem_wrapper(wrap_fd(owner.get_io_context(),
                              this->queue->buffer.get_data_sem().get_fd()))
 {
 }

--- a/src/recv_mem.cpp
+++ b/src/recv_mem.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2019, 2023 National Research Foundation (SARAO)
+/* Copyright 2015, 2019, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -37,7 +37,7 @@ mem_reader::mem_reader(
 void mem_reader::start()
 {
     boost::asio::post(
-        get_io_service(),
+        get_io_context(),
         bind_handler([this] (handler_context, stream_base::add_packet_state &state) {
             mem_to_stream(state, this->ptr, this->length);
             // There will be no more data, so we can stop the stream immediately.

--- a/src/recv_ring_stream.cpp
+++ b/src/recv_ring_stream.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2015, 2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -40,10 +40,10 @@ ring_stream_config &ring_stream_config::set_contiguous_only(bool contiguous_only
 }
 
 ring_stream_base::ring_stream_base(
-    io_service_ref io_service,
+    io_context_ref io_context,
     const stream_config &config,
     const ring_stream_config &ring_config)
-    : stream(std::move(io_service), config),
+    : stream(std::move(io_context), config),
     ring_config(ring_config)
 {
 }

--- a/src/recv_stream.cpp
+++ b/src/recv_stream.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2017-2021, 2023 National Research Foundation (SARAO)
+/* Copyright 2015, 2017-2021, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -626,7 +626,7 @@ stream_stats stream_base::get_stats() const
 
 
 reader::reader(stream &owner)
-    : io_service(owner.get_io_service()), owner(owner.shared)
+    : io_context(owner.get_io_context()), owner(owner.shared)
 {
 }
 
@@ -636,10 +636,10 @@ bool reader::lossy() const
 }
 
 
-stream::stream(io_service_ref io_service, const stream_config &config)
+stream::stream(io_context_ref io_context, const stream_config &config)
     : stream_base(config),
-    thread_pool_holder(std::move(io_service).get_shared_thread_pool()),
-    io_service(*io_service),
+    thread_pool_holder(std::move(io_context).get_shared_thread_pool()),
+    io_context(*io_context),
     readers_started(!config.get_explicit_start())
 {
 }

--- a/src/recv_tcp.cpp
+++ b/src/recv_tcp.cpp
@@ -49,10 +49,10 @@ tcp_reader::tcp_reader(
     buffer(new std::uint8_t[max_size * pkts_per_buffer]),
     head(buffer.get()),
     tail(buffer.get()),
-    peer(get_socket_io_service(acceptor)),
+    peer(get_socket_executor(acceptor)),
     acceptor(std::move(acceptor))
 {
-    assert(socket_uses_io_service(this->acceptor, get_io_service()));
+    assert(socket_uses_io_context(this->acceptor, get_io_context()));
     set_socket_recv_buffer_size(this->acceptor, buffer_size);
 }
 
@@ -76,7 +76,7 @@ tcp_reader::tcp_reader(
     std::size_t buffer_size)
     : tcp_reader(
           owner,
-          boost::asio::ip::tcp::acceptor(owner.get_io_service(), endpoint),
+          boost::asio::ip::tcp::acceptor(owner.get_io_context(), endpoint),
           max_size, buffer_size)
 {
 }

--- a/src/recv_tcp.cpp
+++ b/src/recv_tcp.cpp
@@ -49,7 +49,7 @@ tcp_reader::tcp_reader(
     buffer(new std::uint8_t[max_size * pkts_per_buffer]),
     head(buffer.get()),
     tail(buffer.get()),
-    peer(get_socket_executor(acceptor)),
+    peer(acceptor.get_executor()),
     acceptor(std::move(acceptor))
 {
     assert(socket_uses_io_context(this->acceptor, get_io_context()));

--- a/src/recv_udp.cpp
+++ b/src/recv_udp.cpp
@@ -322,7 +322,7 @@ static void init_ibv_override()
         log_warning("SPEAD2_IBV_INTERFACE found, but ibverbs support not compiled in");
 #else
         boost::system::error_code ec;
-        ibv_interface = boost::asio::ip::address_v4::from_string(interface, ec);
+        ibv_interface = boost::asio::ip::make_address_v4(interface, ec);
         if (ec)
         {
             log_warning("SPEAD2_IBV_INTERFACE could not be parsed as an IPv4 address: %1%", ec.message());

--- a/src/recv_udp.cpp
+++ b/src/recv_udp.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2019-2020, 2023-2024 National Research Foundation (SARAO)
+/* Copyright 2015, 2019-2020, 2023-2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -58,7 +58,7 @@ udp_reader::udp_reader(
 #endif
     socket(std::move(socket))
 {
-    assert(socket_uses_io_service(this->socket, get_io_service()));
+    assert(socket_uses_io_context(this->socket, get_io_context()));
 #if SPEAD2_USE_RECVMMSG
     // Allocate one extra byte so that overflow can be detected.
     size_t buffer_size = max_size + 1;
@@ -96,7 +96,7 @@ void udp_reader::start()
 }
 
 static boost::asio::ip::udp::socket make_v4_socket(
-    boost::asio::io_service &io_service,
+    boost::asio::io_context &io_context,
     const boost::asio::ip::udp::endpoint &endpoint,
     std::size_t buffer_size,
     const boost::asio::ip::address &interface_address)
@@ -110,7 +110,7 @@ static boost::asio::ip::udp::socket make_v4_socket(
         throw std::invalid_argument("endpoint is not an IPv4 address");
     if (!ep.address().is_multicast() && ep.address() != interface_address)
         throw std::invalid_argument("endpoint is not multicast and does not match interface address");
-    boost::asio::ip::udp::socket socket(io_service, ep.protocol());
+    boost::asio::ip::udp::socket socket(io_context, ep.protocol());
     if (ep.address().is_multicast())
     {
         socket.set_option(boost::asio::socket_base::reuse_address(true));
@@ -122,14 +122,14 @@ static boost::asio::ip::udp::socket make_v4_socket(
 }
 
 static boost::asio::ip::udp::socket make_multicast_v6_socket(
-    boost::asio::io_service &io_service,
+    boost::asio::io_context &io_context,
     const boost::asio::ip::udp::endpoint &endpoint,
     std::size_t buffer_size,
     unsigned int interface_index)
 {
     if (!endpoint.address().is_v6() || !endpoint.address().is_multicast())
         throw std::invalid_argument("endpoint is not an IPv6 multicast address");
-    boost::asio::ip::udp::socket socket(io_service, endpoint.protocol());
+    boost::asio::ip::udp::socket socket(io_context, endpoint.protocol());
     socket.set_option(boost::asio::socket_base::reuse_address(true));
     socket.set_option(boost::asio::ip::multicast::join_group(
         endpoint.address().to_v6(), interface_index));
@@ -138,11 +138,11 @@ static boost::asio::ip::udp::socket make_multicast_v6_socket(
 }
 
 static boost::asio::ip::udp::socket make_socket(
-    boost::asio::io_service &io_service,
+    boost::asio::io_context &io_context,
     const boost::asio::ip::udp::endpoint &endpoint,
     std::size_t buffer_size)
 {
-    boost::asio::ip::udp::socket socket(io_service, endpoint.protocol());
+    boost::asio::ip::udp::socket socket(io_context, endpoint.protocol());
     if (endpoint.address().is_multicast())
     {
         socket.set_option(boost::asio::socket_base::reuse_address(true));
@@ -159,7 +159,7 @@ udp_reader::udp_reader(
     std::size_t buffer_size)
     : udp_reader(
         owner,
-        make_socket(owner.get_io_service(), endpoint, buffer_size),
+        make_socket(owner.get_io_context(), endpoint, buffer_size),
         max_size)
 {
     bind_endpoint = endpoint;
@@ -173,7 +173,7 @@ udp_reader::udp_reader(
     const boost::asio::ip::address &interface_address)
     : udp_reader(
         owner,
-        make_v4_socket(owner.get_io_service(),
+        make_v4_socket(owner.get_io_context(),
                        endpoint, buffer_size, interface_address),
         max_size)
 {
@@ -192,7 +192,7 @@ udp_reader::udp_reader(
     unsigned int interface_index)
     : udp_reader(
         owner,
-        make_multicast_v6_socket(owner.get_io_service(),
+        make_multicast_v6_socket(owner.get_io_context(),
                                  endpoint, buffer_size, interface_index),
         max_size)
 {

--- a/src/recv_udp_ibv.cpp
+++ b/src/recv_udp_ibv.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2016-2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -79,9 +79,9 @@ udp_ibv_reader_core::udp_ibv_reader_core(
     stream &owner,
     const udp_ibv_config &config)
     : udp_reader_base(owner),
-    join_socket(owner.get_io_service(), boost::asio::ip::udp::v4()),
+    join_socket(owner.get_io_context(), boost::asio::ip::udp::v4()),
     event_channel(nullptr),
-    comp_channel_wrapper(owner.get_io_service()),
+    comp_channel_wrapper(owner.get_io_context()),
     max_size(config.get_max_size()),
     max_poll(config.get_max_poll())
 {
@@ -96,7 +96,7 @@ udp_ibv_reader_core::udp_ibv_reader_core(
     if (config.get_comp_vector() >= 0)
     {
         comp_channel = ibv_comp_channel_t(cm_id);
-        comp_channel_wrapper = comp_channel.wrap(get_io_service());
+        comp_channel_wrapper = comp_channel.wrap(get_io_context());
     }
 
     for (const auto &endpoint : config.get_endpoints())

--- a/src/recv_udp_pcap.cpp
+++ b/src/recv_udp_pcap.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2016-2017, 2019, 2023 National Research Foundation (SARAO)
+/* Copyright 2016-2017, 2019, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -92,7 +92,7 @@ void udp_pcap_file_reader::run(handler_context ctx, stream_base::add_packet_stat
     if (!state.is_stopped())
     {
         using namespace std::placeholders;
-        boost::asio::post(get_io_service(), bind_handler(std::move(ctx), std::bind(&udp_pcap_file_reader::run, this, _1, _2)));
+        boost::asio::post(get_io_context(), bind_handler(std::move(ctx), std::bind(&udp_pcap_file_reader::run, this, _1, _2)));
     }
 }
 
@@ -132,7 +132,7 @@ void udp_pcap_file_reader::start()
 {
     // Process the file
     using namespace std::placeholders;
-    boost::asio::post(get_io_service(), bind_handler(std::bind(&udp_pcap_file_reader::run, this, _1, _2)));
+    boost::asio::post(get_io_context(), bind_handler(std::bind(&udp_pcap_file_reader::run, this, _1, _2)));
 }
 
 udp_pcap_file_reader::~udp_pcap_file_reader()

--- a/src/send_inproc.cpp
+++ b/src/send_inproc.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2018-2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2018-2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -52,7 +52,7 @@ private:
 public:
     /// Constructor
     inproc_writer(
-        io_service_ref io_service,
+        io_context_ref io_context,
         const std::vector<std::shared_ptr<inproc_queue>> &queues,
         const stream_config &config);
 
@@ -100,10 +100,10 @@ const std::vector<std::shared_ptr<inproc_queue>> &inproc_writer::get_queues() co
 }
 
 inproc_writer::inproc_writer(
-    io_service_ref io_service,
+    io_context_ref io_context,
     const std::vector<std::shared_ptr<inproc_queue>> &queues,
     const stream_config &config)
-    : writer(std::move(io_service), config),
+    : writer(std::move(io_context), config),
     queues(queues),
     scratch(new std::uint8_t[config.get_max_packet_size()])
 {
@@ -114,10 +114,10 @@ inproc_writer::inproc_writer(
 } // anonymous namespace
 
 inproc_stream::inproc_stream(
-    io_service_ref io_service,
+    io_context_ref io_context,
     const std::vector<std::shared_ptr<inproc_queue>> &queues,
     const stream_config &config)
-    : stream(std::make_unique<inproc_writer>(std::move(io_service), queues, config))
+    : stream(std::make_unique<inproc_writer>(std::move(io_context), queues, config))
 {
 }
 

--- a/src/send_stream.cpp
+++ b/src/send_stream.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2017, 2019-2020, 2023-2024 National Research Foundation (SARAO)
+/* Copyright 2015, 2017, 2019-2020, 2023-2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -106,9 +106,14 @@ stream::~stream()
     }
 }
 
-boost::asio::io_service &stream::get_io_service() const
+boost::asio::io_context &stream::get_io_context() const
 {
-    return w->get_io_service();
+    return w->get_io_context();
+}
+
+boost::asio::io_context &stream::get_io_service() const
+{
+    return w->get_io_context();
 }
 
 void stream::set_cnt_sequence(item_pointer_t next, item_pointer_t step)

--- a/src/send_streambuf.cpp
+++ b/src/send_streambuf.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2019-2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2015, 2019-2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -38,7 +38,7 @@ private:
 public:
     /// Constructor
     streambuf_writer(
-        io_service_ref io_service,
+        io_context_ref io_context,
         std::streambuf &streambuf,
         const stream_config &config);
 
@@ -91,10 +91,10 @@ void streambuf_writer::wakeup()
 }
 
 streambuf_writer::streambuf_writer(
-    io_service_ref io_service,
+    io_context_ref io_context,
     std::streambuf &streambuf,
     const stream_config &config)
-    : writer(std::move(io_service), config), streambuf(streambuf),
+    : writer(std::move(io_context), config), streambuf(streambuf),
     scratch(new std::uint8_t[config.get_max_packet_size()])
 {
 }
@@ -102,10 +102,10 @@ streambuf_writer::streambuf_writer(
 } // anonymous namespace
 
 streambuf_stream::streambuf_stream(
-    io_service_ref io_service,
+    io_context_ref io_context,
     std::streambuf &streambuf,
     const stream_config &config)
-    : stream(std::make_unique<streambuf_writer>(std::move(io_service), streambuf, config))
+    : stream(std::make_unique<streambuf_writer>(std::move(io_context), streambuf, config))
 {
 }
 

--- a/src/send_streambuf.cpp
+++ b/src/send_streambuf.cpp
@@ -59,8 +59,8 @@ void streambuf_writer::wakeup()
 
         for (const auto &buffer : data.buffers)
         {
-            std::size_t buffer_size = boost::asio::buffer_size(buffer);
-            std::size_t written = streambuf.sputn(boost::asio::buffer_cast<const char *>(buffer), buffer_size);
+            std::size_t buffer_size = buffer.size();
+            std::size_t written = streambuf.sputn(static_cast<const char *>(buffer.data()), buffer_size);
             data.item->bytes_sent += written;
             if (written != buffer_size)
             {

--- a/src/send_udp.cpp
+++ b/src/send_udp.cpp
@@ -314,9 +314,8 @@ void udp_writer::wakeup()
     {
         for (const auto &buffer : packets[i].packet.buffers)
         {
-            msg_iov[iov].iov_base = const_cast<void *>(
-                boost::asio::buffer_cast<const void *>(buffer));
-            msg_iov[iov].iov_len = boost::asio::buffer_size(buffer);
+            msg_iov[iov].iov_base = const_cast<void *>(buffer.data());
+            msg_iov[iov].iov_len = buffer.size();
             iov++;
         }
     }

--- a/src/send_udp.cpp
+++ b/src/send_udp.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2019-2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2015, 2019-2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -95,7 +95,7 @@ private:
 
 public:
     udp_writer(
-        io_service_ref io_service,
+        io_context_ref io_context,
         boost::asio::ip::udp::socket &&socket,
         const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
         const stream_config &config,
@@ -381,20 +381,20 @@ void udp_writer::wakeup()
 #endif // !SPEAD2_USE_SENDMMSG
 
 udp_writer::udp_writer(
-    io_service_ref io_service,
+    io_context_ref io_context,
     boost::asio::ip::udp::socket &&socket,
     const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
     const stream_config &config,
     std::size_t buffer_size)
-    : writer(std::move(io_service), config),
+    : writer(std::move(io_context), config),
     socket(std::move(socket)),
     endpoints(endpoints)
 #if !SPEAD2_USE_SENDMMSG
     , scratch(new std::uint8_t[config.get_max_packet_size()])
 #endif
 {
-    if (!socket_uses_io_service(this->socket, get_io_service()))
-        throw std::invalid_argument("I/O service does not match the socket's I/O service");
+    if (!socket_uses_io_context(this->socket, get_io_context()))
+        throw std::invalid_argument("I/O context does not match the socket's I/O context");
     auto protocol = this->socket.local_endpoint().protocol();
     for (const auto &endpoint : endpoints)
         if (endpoint.protocol() != protocol)
@@ -411,11 +411,11 @@ udp_writer::udp_writer(
 } // anonymous namespace
 
 static boost::asio::ip::udp::socket make_socket(
-    boost::asio::io_service &io_service,
+    boost::asio::io_context &io_context,
     const boost::asio::ip::udp &protocol,
     const boost::asio::ip::address &interface_address)
 {
-    boost::asio::ip::udp::socket socket(io_service, protocol);
+    boost::asio::ip::udp::socket socket(io_context, protocol);
     if (!interface_address.is_unspecified())
         socket.bind(boost::asio::ip::udp::endpoint(interface_address, 0));
     return socket;
@@ -429,32 +429,32 @@ static boost::asio::ip::udp get_protocol(const std::vector<boost::asio::ip::udp:
 }
 
 udp_stream::udp_stream(
-    io_service_ref io_service,
+    io_context_ref io_context,
     const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
     const stream_config &config,
     std::size_t buffer_size,
     const boost::asio::ip::address &interface_address)
-    : udp_stream(io_service,
-                 make_socket(*io_service, get_protocol(endpoints), interface_address),
+    : udp_stream(io_context,
+                 make_socket(*io_context, get_protocol(endpoints), interface_address),
                  endpoints, config, buffer_size)
 {
 }
 
 static boost::asio::ip::udp::socket make_multicast_socket(
-    boost::asio::io_service &io_service,
+    boost::asio::io_context &io_context,
     const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
     int ttl)
 {
     for (const auto &endpoint : endpoints)
         if (!endpoint.address().is_multicast())
             throw std::invalid_argument("endpoint is not a multicast address");
-    boost::asio::ip::udp::socket socket(io_service, get_protocol(endpoints));
+    boost::asio::ip::udp::socket socket(io_context, get_protocol(endpoints));
     socket.set_option(boost::asio::ip::multicast::hops(ttl));
     return socket;
 }
 
 static boost::asio::ip::udp::socket make_multicast_v4_socket(
-    boost::asio::io_service &io_service,
+    boost::asio::io_context &io_context,
     const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
     int ttl,
     const boost::asio::ip::address &interface_address)
@@ -464,7 +464,7 @@ static boost::asio::ip::udp::socket make_multicast_v4_socket(
             throw std::invalid_argument("endpoint is not an IPv4 multicast address");
     if (!interface_address.is_unspecified() && !interface_address.is_v4())
         throw std::invalid_argument("interface address is not an IPv4 address");
-    boost::asio::ip::udp::socket socket(io_service, boost::asio::ip::udp::v4());
+    boost::asio::ip::udp::socket socket(io_context, boost::asio::ip::udp::v4());
     socket.set_option(boost::asio::ip::multicast::hops(ttl));
     if (!interface_address.is_unspecified())
         socket.set_option(boost::asio::ip::multicast::outbound_interface(interface_address.to_v4()));
@@ -472,65 +472,65 @@ static boost::asio::ip::udp::socket make_multicast_v4_socket(
 }
 
 static boost::asio::ip::udp::socket make_multicast_v6_socket(
-    boost::asio::io_service &io_service,
+    boost::asio::io_context &io_context,
     const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
     int ttl, unsigned int interface_index)
 {
     for (const auto &endpoint : endpoints)
         if (!endpoint.address().is_v6() || !endpoint.address().is_multicast())
             throw std::invalid_argument("endpoint is not an IPv4 multicast address");
-    boost::asio::ip::udp::socket socket(io_service, boost::asio::ip::udp::v6());
+    boost::asio::ip::udp::socket socket(io_context, boost::asio::ip::udp::v6());
     socket.set_option(boost::asio::ip::multicast::hops(ttl));
     socket.set_option(boost::asio::ip::multicast::outbound_interface(interface_index));
     return socket;
 }
 
 udp_stream::udp_stream(
-    io_service_ref io_service,
+    io_context_ref io_context,
     const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
     const stream_config &config,
     std::size_t buffer_size,
     int ttl)
-    : udp_stream(io_service,
-                 make_multicast_socket(*io_service, endpoints, ttl),
+    : udp_stream(io_context,
+                 make_multicast_socket(*io_context, endpoints, ttl),
                  std::move(endpoints), config, buffer_size)
 {
 }
 
 udp_stream::udp_stream(
-    io_service_ref io_service,
+    io_context_ref io_context,
     const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
     const stream_config &config,
     std::size_t buffer_size,
     int ttl,
     const boost::asio::ip::address &interface_address)
-    : udp_stream(io_service,
-                 make_multicast_v4_socket(*io_service, endpoints, ttl, interface_address),
+    : udp_stream(io_context,
+                 make_multicast_v4_socket(*io_context, endpoints, ttl, interface_address),
                  std::move(endpoints), config, buffer_size)
 {
 }
 
 udp_stream::udp_stream(
-    io_service_ref io_service,
+    io_context_ref io_context,
     const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
     const stream_config &config,
     std::size_t buffer_size,
     int ttl,
     unsigned int interface_index)
-    : udp_stream(io_service,
-                 make_multicast_v6_socket(*io_service, endpoints, ttl, interface_index),
+    : udp_stream(io_context,
+                 make_multicast_v6_socket(*io_context, endpoints, ttl, interface_index),
                  std::move(endpoints), config, buffer_size)
 {
 }
 
 udp_stream::udp_stream(
-    io_service_ref io_service,
+    io_context_ref io_context,
     boost::asio::ip::udp::socket &&socket,
     const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
     const stream_config &config,
     std::size_t buffer_size)
     : stream(std::make_unique<udp_writer>(
-        std::move(io_service),
+        std::move(io_context),
         std::move(socket),
         endpoints,
         config,
@@ -539,11 +539,11 @@ udp_stream::udp_stream(
 }
 
 udp_stream::udp_stream(
-    io_service_ref io_service,
+    io_context_ref io_context,
     boost::asio::ip::udp::socket &&socket,
     const std::vector<boost::asio::ip::udp::endpoint> &endpoints,
     const stream_config &config)
-    : udp_stream(io_service, std::move(socket), endpoints, config, 0)
+    : udp_stream(io_context, std::move(socket), endpoints, config, 0)
 {
 }
 

--- a/src/send_udp_ibv.cpp
+++ b/src/send_udp_ibv.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2016, 2019-2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2016, 2019-2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -142,7 +142,7 @@ private:
 
 public:
     udp_ibv_writer(
-        io_service_ref io_service,
+        io_context_ref io_context,
         const stream_config &config,
         const udp_ibv_config &ibv_config);
 
@@ -452,16 +452,16 @@ static std::size_t calc_target_batch(const stream_config &config, std::size_t n_
 }
 
 udp_ibv_writer::udp_ibv_writer(
-    io_service_ref io_service,
+    io_context_ref io_context,
     const stream_config &config,
     const udp_ibv_config &ibv_config)
-    : writer(std::move(io_service), config),
+    : writer(std::move(io_context), config),
     n_slots(calc_n_slots(config, ibv_config.get_buffer_size())),
     target_batch(calc_target_batch(config, n_slots)),
-    socket(get_io_service(), boost::asio::ip::udp::v4()),
+    socket(get_io_context(), boost::asio::ip::udp::v4()),
     endpoints(ibv_config.get_endpoints()),
     event_channel(nullptr),
-    comp_channel_wrapper(get_io_service()),
+    comp_channel_wrapper(get_io_context()),
     available(n_slots),
     max_poll(ibv_config.get_max_poll())
 {
@@ -494,7 +494,7 @@ udp_ibv_writer::udp_ibv_writer(
     if (comp_vector >= 0)
     {
         comp_channel = ibv_comp_channel_t(cm_id);
-        comp_channel_wrapper = comp_channel.wrap(get_io_service());
+        comp_channel_wrapper = comp_channel.wrap(get_io_context());
         send_cq = ibv_cq_t(cm_id, n_slots, nullptr,
                            comp_channel, comp_vector % cm_id->verbs->num_comp_vectors);
     }
@@ -594,10 +594,10 @@ udp_ibv_config &udp_ibv_config::add_memory_region(const void *ptr, std::size_t s
 }
 
 udp_ibv_stream::udp_ibv_stream(
-    io_service_ref io_service,
+    io_context_ref io_context,
     const stream_config &config,
     const udp_ibv_config &ibv_config)
-    : stream(std::make_unique<udp_ibv_writer>(std::move(io_service), config, ibv_config))
+    : stream(std::make_unique<udp_ibv_writer>(std::move(io_context), config, ibv_config))
 {
 }
 

--- a/src/send_udp_ibv.cpp
+++ b/src/send_udp_ibv.cpp
@@ -340,7 +340,7 @@ void udp_ibv_writer::wakeup()
             s->sge[0].lkey = mr->lkey;
             // The packet_generator writes the SPEAD header and item pointers
             // directly into the payload.
-            assert(boost::asio::buffer_cast<const std::uint8_t *>(data.buffers[0]) == s->payload);
+            assert(data.buffers[0].data() == s->payload);
             std::uint8_t *copy_target = s->payload + boost::asio::buffer_size(data.buffers[0]);
             s->sge[0].length = copy_target - s->frame.data();
             /* The first SGE is used for both the IP/UDP header and the
@@ -356,7 +356,7 @@ void udp_ibv_writer::wakeup()
             {
                 const auto &buffer = data.buffers[j];
                 ibv_sge cur;
-                const std::uint8_t *ptr = boost::asio::buffer_cast<const uint8_t *>(buffer);
+                const std::uint8_t *ptr = static_cast<const std::uint8_t *>(buffer.data());
                 cur.length = boost::asio::buffer_size(buffer);
                 // Check if it belongs to a user-registered region
                 memory_region cmp(ptr, cur.length);
@@ -548,7 +548,7 @@ udp_ibv_writer::udp_ibv_writer(
         udp.destination_port(endpoints[0].port());
         udp.length(config.get_max_packet_size() + udp_packet::min_size);
         udp.checksum(0);
-        slots[i].payload = boost::asio::buffer_cast<std::uint8_t *>(udp.payload());
+        slots[i].payload = static_cast<std::uint8_t *>(udp.payload().data());
     }
 
     if (cm_id.query_device_ex().raw_packet_caps & IBV_RAW_PACKET_CAP_IP_CSUM)

--- a/src/send_writer.cpp
+++ b/src/send_writer.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020, 2023-2024 National Research Foundation (SARAO)
+/* Copyright 2020, 2023-2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -301,13 +301,13 @@ void writer::request_wakeup()
 
 void writer::post_wakeup()
 {
-    get_io_service().post([this]() { wakeup(); });
+    get_io_context().post([this]() { wakeup(); });
 }
 
-writer::writer(io_service_ref io_service, const stream_config &config)
+writer::writer(io_context_ref io_context, const stream_config &config)
     : config(config),
-    io_service(std::move(io_service)),
-    timer(*this->io_service)
+    io_context(std::move(io_context)),
+    timer(*this->io_context)
 {
 }
 

--- a/src/send_writer.cpp
+++ b/src/send_writer.cpp
@@ -301,7 +301,7 @@ void writer::request_wakeup()
 
 void writer::post_wakeup()
 {
-    get_io_context().post([this]() { wakeup(); });
+    boost::asio::post(get_io_context(), [this]() { wakeup(); });
 }
 
 writer::writer(io_context_ref io_context, const stream_config &config)

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -292,7 +292,7 @@ std::int64_t sender::run()
     /* See comments in spead2_send.cpp for the explanation of why this is
      * posted rather than run directly.
      */
-    stream.get_io_context().post([this] {
+    boost::asio::post(stream.get_io_context(), [this] {
         for (std::size_t i = 0; i < max_heaps; i++)
             stream.async_send_heap(heaps[i], [this, i] (const boost::system::error_code &ec, std::size_t bytes_transferred) {
                 callback(i, ec, bytes_transferred); });

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -563,13 +563,12 @@ static void main_agent(int argc, const char **argv)
 
     /* Look up the bind address for the control socket */
     tcp::resolver tcp_resolver(thread_pool.get_io_context());
-    tcp::resolver::query tcp_query("0.0.0.0", agent_opts.endpoint);
-    tcp::endpoint tcp_endpoint = *tcp_resolver.resolve(tcp_query);
+    tcp::endpoint tcp_endpoint = *tcp_resolver.resolve("0.0.0.0", agent_opts.endpoint).begin();
     tcp::acceptor acceptor(thread_pool.get_io_context(), tcp_endpoint);
     while (true)
     {
         tcp::iostream control;
-        acceptor.accept(*control.rdbuf());
+        acceptor.accept(control.rdbuf()->socket());
         std::unique_ptr<recv_connection> connection;
         while (true)
         {

--- a/src/spead2_bench.cpp
+++ b/src/spead2_bench.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2017, 2019-2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2015, 2017, 2019-2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -292,7 +292,7 @@ std::int64_t sender::run()
     /* See comments in spead2_send.cpp for the explanation of why this is
      * posted rather than run directly.
      */
-    stream.get_io_service().post([this] {
+    stream.get_io_context().post([this] {
         for (std::size_t i = 0; i < max_heaps; i++)
             stream.async_send_heap(heaps[i], [this, i] (const boost::system::error_code &ec, std::size_t bytes_transferred) {
                 callback(i, ec, bytes_transferred); });
@@ -365,7 +365,7 @@ static std::pair<bool, double> measure_connection_once(
         auto start = std::chrono::high_resolution_clock::now();
         std::int64_t transferred;
         std::unique_ptr<spead2::send::stream> stream = sender_options.make_stream(
-            thread_pool.get_io_service(),
+            thread_pool.get_io_context(),
             opts.protocol,
             {endpoint},
             {{data.data(), data.size() * sizeof(data[0])}});
@@ -562,10 +562,10 @@ static void main_agent(int argc, const char **argv)
     spead2::thread_pool thread_pool;
 
     /* Look up the bind address for the control socket */
-    tcp::resolver tcp_resolver(thread_pool.get_io_service());
+    tcp::resolver tcp_resolver(thread_pool.get_io_context());
     tcp::resolver::query tcp_query("0.0.0.0", agent_opts.endpoint);
     tcp::endpoint tcp_endpoint = *tcp_resolver.resolve(tcp_query);
-    tcp::acceptor acceptor(thread_pool.get_io_service(), tcp_endpoint);
+    tcp::acceptor acceptor(thread_pool.get_io_context(), tcp_endpoint);
     while (true)
     {
         tcp::iostream control;
@@ -636,7 +636,7 @@ static void build_streambuf(std::streambuf &streambuf, const options &opts, std:
     spead2::thread_pool thread_pool;
     spead2::flavour flavour = opts.sender.make_flavour(opts.protocol);
     spead2::send::streambuf_stream stream(
-        thread_pool.get_io_service(), streambuf,
+        thread_pool.get_io_context(), streambuf,
         opts.sender.make_stream_config());
     spead2::send::heap heap(flavour), end_heap(flavour);
     std::vector<std::uint8_t> data(opts.heap_size);

--- a/src/spead2_cmdline.cpp
+++ b/src/spead2_cmdline.cpp
@@ -234,7 +234,7 @@ void receiver_options::add_readers(
             {
                 stream.emplace_reader<spead2::recv::udp_reader>(
                     ep, *max_packet_size, *buffer_size,
-                    boost::asio::ip::address_v4::from_string(interface_address));
+                    boost::asio::ip::make_address_v4(interface_address));
             }
             else
             {
@@ -247,7 +247,7 @@ void receiver_options::add_readers(
 #if SPEAD2_USE_IBV
     if (!ibv_endpoints.empty())
     {
-        boost::asio::ip::address interface_address = boost::asio::ip::address::from_string(this->interface_address);
+        boost::asio::ip::address interface_address = boost::asio::ip::make_address(this->interface_address);
         stream.emplace_reader<spead2::recv::udp_ibv_reader>(
             udp_ibv_config()
                 .set_endpoints(ibv_endpoints)
@@ -344,7 +344,7 @@ std::unique_ptr<stream> sender_options::make_stream(
     stream_config config = make_stream_config();
     boost::asio::ip::address interface_address;
     if (!this->interface_address.empty())
-        interface_address = boost::asio::ip::address::from_string(this->interface_address);
+        interface_address = boost::asio::ip::make_address(this->interface_address);
     if (protocol.tcp)
     {
         auto ep = parse_endpoints<boost::asio::ip::tcp>(io_context, endpoints, false);

--- a/src/spead2_cmdline.cpp
+++ b/src/spead2_cmdline.cpp
@@ -71,10 +71,9 @@ std::vector<boost::asio::ip::basic_endpoint<Proto>> parse_endpoints(
             host = dest.substr(0, colon);
             port = dest.substr(colon + 1);
         }
-        typename resolver_type::query query(
+        ans.push_back(*resolver.resolve(
             host, port,
-            passive ? resolver_type::query::passive : typename resolver_type::query::flags());
-        ans.push_back(*resolver.resolve(query));
+            passive ? resolver_type::passive : typename resolver_type::flags()).begin());
     }
     return ans;
 }

--- a/src/spead2_cmdline.h
+++ b/src/spead2_cmdline.h
@@ -1,4 +1,4 @@
-/* Copyright 2020 National Research Foundation (SARAO)
+/* Copyright 2020, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -148,17 +148,17 @@ struct protocol_options
  */
 template<typename Proto>
 std::vector<boost::asio::ip::basic_endpoint<Proto>> parse_endpoints(
-    boost::asio::io_service &io_service, const std::vector<std::string> &endpoints, bool passive);
+    boost::asio::io_context &io_context, const std::vector<std::string> &endpoints, bool passive);
 
 /// Like @ref parse_endpoints, but for a single endpoint.
 template<typename Proto>
 static inline boost::asio::ip::basic_endpoint<Proto> parse_endpoint(
-    boost::asio::io_service &io_service, const std::string &endpoint, bool passive)
+    boost::asio::io_context &io_context, const std::string &endpoint, bool passive)
 {
-    return parse_endpoints<Proto>(io_service, {endpoint}, passive)[0];
+    return parse_endpoints<Proto>(io_context, {endpoint}, passive)[0];
 }
 
-// Variants which provide their own io_service
+// Variants which provide their own io_context
 template<typename Proto>
 std::vector<boost::asio::ip::basic_endpoint<Proto>> parse_endpoints(
     const std::vector<std::string> &endpoints, bool passive);
@@ -301,7 +301,7 @@ struct sender_options
      * @a memory_regions is used with @ref udp_ibv_stream.
      */
     std::unique_ptr<stream> make_stream(
-        boost::asio::io_service &io_service,
+        boost::asio::io_context &io_context,
         const protocol_options &protocol,
         const std::vector<std::string> &endpoints,
         const std::vector<std::pair<const void *, std::size_t>> &memory_regions) const;

--- a/src/spead2_recv.cpp
+++ b/src/spead2_recv.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2018-2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2015, 2018-2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -343,7 +343,7 @@ int main(int argc, const char **argv)
     }
 
     spead2::thread_pool stopper_thread_pool;
-    boost::asio::signal_set signals(stopper_thread_pool.get_io_service());
+    boost::asio::signal_set signals(stopper_thread_pool.get_io_context());
     signals.add(SIGINT);
     signals.async_wait([&streams] (const boost::system::error_code &error,
                                    [[maybe_unused]] int signal_number) {

--- a/src/spead2_send.cpp
+++ b/src/spead2_send.cpp
@@ -273,7 +273,7 @@ std::uint64_t sender::run(spead2::send::stream &stream)
      * callbacks can happen until the initial heaps are all sent, which would
      * otherwise lead to heaps being queued out of order.
      */
-    stream.get_io_context().post([this, &stream] {
+    boost::asio::post(stream.get_io_context(), [this, &stream] {
         for (std::size_t i = 0; i < max_heaps; i++)
             stream.async_send_heap(
                 get_heap(i),

--- a/src/spead2_send.cpp
+++ b/src/spead2_send.cpp
@@ -303,25 +303,6 @@ static int run(spead2::send::stream &stream, sender &s)
     return 0;
 }
 
-template <typename Proto>
-static std::vector<boost::asio::ip::basic_endpoint<Proto>> get_endpoints(
-    boost::asio::io_context &io_context, const options &opts)
-{
-    typedef boost::asio::ip::basic_resolver<Proto> resolver_type;
-    resolver_type resolver(io_context);
-    std::vector<boost::asio::ip::basic_endpoint<Proto>> ans;
-    ans.reserve(opts.dest.size());
-    for (const std::string &dest : opts.dest)
-    {
-        auto colon = dest.rfind(':');
-        if (colon == std::string::npos)
-            throw std::runtime_error("Destination '" + dest + "' does not have the format host:port");
-        typename resolver_type::query query(dest.substr(0, colon), dest.substr(colon + 1));
-        ans.push_back(*resolver.resolve(query));
-    }
-    return ans;
-}
-
 int main(int argc, const char **argv)
 {
     options opts = parse_args(argc, argv);

--- a/src/spead2_send.cpp
+++ b/src/spead2_send.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2016, 2017, 2019-2020, 2023 National Research Foundation (SARAO)
+/* Copyright 2016, 2017, 2019-2020, 2023, 2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -273,7 +273,7 @@ std::uint64_t sender::run(spead2::send::stream &stream)
      * callbacks can happen until the initial heaps are all sent, which would
      * otherwise lead to heaps being queued out of order.
      */
-    stream.get_io_service().post([this, &stream] {
+    stream.get_io_context().post([this, &stream] {
         for (std::size_t i = 0; i < max_heaps; i++)
             stream.async_send_heap(
                 get_heap(i),
@@ -305,10 +305,10 @@ static int run(spead2::send::stream &stream, sender &s)
 
 template <typename Proto>
 static std::vector<boost::asio::ip::basic_endpoint<Proto>> get_endpoints(
-    boost::asio::io_service &io_service, const options &opts)
+    boost::asio::io_context &io_context, const options &opts)
 {
     typedef boost::asio::ip::basic_resolver<Proto> resolver_type;
-    resolver_type resolver(io_service);
+    resolver_type resolver(io_context);
     std::vector<boost::asio::ip::basic_endpoint<Proto>> ans;
     ans.reserve(opts.dest.size());
     for (const std::string &dest : opts.dest)
@@ -330,7 +330,7 @@ int main(int argc, const char **argv)
 
     spead2::thread_pool thread_pool(1);
     std::unique_ptr<spead2::send::stream> stream =
-        opts.sender.make_stream(thread_pool.get_io_service(), opts.protocol,
+        opts.sender.make_stream(thread_pool.get_io_context(), opts.protocol,
                                 opts.dest, s.memory_regions());
     return run(*stream, s);
 }

--- a/src/unittest_raw_packet.cpp
+++ b/src/unittest_raw_packet.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2019, 2023-2024 National Research Foundation (SARAO)
+/* Copyright 2019, 2023-2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -46,8 +46,8 @@ static const std::uint8_t sample_ipv4_packet[] =
 // Properties of these sample packets
 static const mac_address source_mac = {{0x1c, 0x1b, 0x0d, 0xe0, 0xd0, 0xfd}};
 static const mac_address destination_mac = {{0x01, 0x00, 0x5e, 0x66, 0xfe, 0x01}};
-static const auto source_address = boost::asio::ip::address_v4::from_string("10.8.2.179");
-static const auto destination_address = boost::asio::ip::address_v4::from_string("239.102.254.1");
+static const auto source_address = boost::asio::ip::make_address_v4("10.8.2.179");
+static const auto destination_address = boost::asio::ip::make_address_v4("239.102.254.1");
 static const std::uint16_t source_port = 34653;
 static const std::uint16_t destination_port = 8888;
 static const std::uint16_t ipv4_identification = 0xaea3;
@@ -75,8 +75,8 @@ BOOST_FIXTURE_TEST_SUITE(raw_packet, packet_data)
 
 static std::string buffer_to_string(const boost::asio::const_buffer &buffer)
 {
-    return std::string(boost::asio::buffer_cast<const char *>(buffer),
-                       boost::asio::buffer_cast<const char *>(buffer) + boost::asio::buffer_size(buffer));
+    const char *data = static_cast<const char *>(buffer.data());
+    return std::string(data, data + buffer.size());
 }
 
 static std::string buffer_to_string(const boost::asio::mutable_buffer &buffer)
@@ -86,7 +86,7 @@ static std::string buffer_to_string(const boost::asio::mutable_buffer &buffer)
 
 BOOST_AUTO_TEST_CASE(multicast_mac)
 {
-    auto address = boost::asio::ip::address::from_string("239.202.234.100");
+    auto address = boost::asio::ip::make_address("239.202.234.100");
     mac_address result = spead2::multicast_mac(address);
     mac_address expected = {{0x01, 0x00, 0x5e, 0x4a, 0xea, 0x64}};
     BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(),
@@ -98,11 +98,11 @@ BOOST_AUTO_TEST_CASE(multicast_mac)
  */
 BOOST_AUTO_TEST_CASE(interface_mac_lo)
 {
-    auto address = boost::asio::ip::address::from_string("127.0.0.1");
+    auto address = boost::asio::ip::make_address("127.0.0.1");
     BOOST_CHECK_THROW(spead2::interface_mac(address), std::runtime_error);
-    address = boost::asio::ip::address::from_string("0.0.0.0");
+    address = boost::asio::ip::make_address("0.0.0.0");
     BOOST_CHECK_THROW(spead2::interface_mac(address), std::runtime_error);
-    address = boost::asio::ip::address::from_string("::1");
+    address = boost::asio::ip::make_address("::1");
     BOOST_CHECK_THROW(spead2::interface_mac(address), std::runtime_error);
 }
 

--- a/src/unittest_send_tcp.cpp
+++ b/src/unittest_send_tcp.cpp
@@ -1,4 +1,4 @@
-;/* Copyright 2020, 2023-2024 National Research Foundation (SARAO)
+;/* Copyright 2020, 2023-2025 National Research Foundation (SARAO)
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Lesser General Public License as published by the Free
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(connect_fail)
     boost::system::error_code heap_error;
 
     boost::asio::ip::tcp::endpoint endpoint(
-        boost::asio::ip::address_v4::from_string("127.0.0.1"),
+        boost::asio::ip::make_address_v4("127.0.0.1"),
         unused_tcp_port());
     spead2::send::tcp_stream stream(
         tp, [&](const boost::system::error_code &ec) { connect_error = ec; },


### PR DESCRIPTION
Boost 1.87 dropped a lot of deprecated functionality that spead2 was still using. Modernise to use the new forms, which seem to have been available since at least Boost 1.70, which is now the minimum.