### PR TITLE
Bump jinja2 to 3.1.5

### DIFF
--- a/requirements-readthedocs.txt
+++ b/requirements-readthedocs.txt
@@ -14,7 +14,7 @@ exceptiongroup==1.2.2
 idna==3.8
 imagesize==1.4.1
 iniconfig==2.0.0
-jinja2==3.1.4
+jinja2==3.1.5
 llvmlite==0.43.0
 markupsafe==2.1.5
 netifaces2==0.0.22


### PR DESCRIPTION
I don't think it should matter (we're not using Jinja's sandbox or untrusted inputs) but this should keep dependabot happy.