### PR TITLE
Use native ARM runners for building aarch64 wheels

### DIFF
--- a/.ci/install-sys-pkgs.sh
+++ b/.ci/install-sys-pkgs.sh
@@ -10,7 +10,7 @@ if [ "$(uname -s)" = "Linux" ]; then
     # install g++-NN but not sccache. This splits on whitespace and we end up
     # with the last component.
     for CXX_PKG in $CXX; do :; done
-    $SUDO apt-get -y --no-install-recommends install \
+    $SUDO apt-get update && $SUDO apt-get -y --no-install-recommends install \
         "$CXX_PKG" \
         ninja-build \
         gcc \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,23 +206,25 @@ jobs:
 
   cibuildwheel-linux:
     needs: [test-cxx, test-python, coverage, lint]
-    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         arch: [x86_64, aarch64]
         python: [cp39, cp310, cp311, cp312, cp313]
+        # Set os based on arch
+        include:
+          - arch: x86_64
+            os: ubuntu-24.04
+          - arch: aarch64
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
     env:
       SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v4
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.7
-      - uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-        if: matrix.arch != 'x86_64'
-      - uses: pypa/cibuildwheel@v2.22.0
+      - uses: pypa/cibuildwheel@v2.23.0
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.python }}-manylinux*
@@ -249,7 +251,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.7
-      - uses: pypa/cibuildwheel@v2.22.0
+      - uses: pypa/cibuildwheel@v2.23.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-macos*
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
This should speed things up significantly

Also build cibuildwheel to 2.23.0, which officially supports these
runners.