### PR TITLE
Update pytest to 9.0.3

### DIFF
--- a/requirements-readthedocs.txt
+++ b/requirements-readthedocs.txt
@@ -53,7 +53,7 @@ pygments==2.20.0
     #   -r requirements.txt
     #   pytest
     #   sphinx
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   -r requirements.txt
     #   pytest-asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ pytest==8.4.2 ; python_full_version < '3.10'
     #   pytest-asyncio
     #   pytest-custom-exit-code
     #   pytest-timeout
-pytest==9.0.2 ; python_full_version >= '3.10'
+pytest==9.0.3 ; python_full_version >= '3.10'
     # via
     #   spead2 (pyproject.toml)
     #   pytest-asyncio


### PR DESCRIPTION
Addresses a dependabot alert. It's probably not that relevant to the cases where we use the requirements files (CI environments where we don't need to worry about other untrusted users in the same container).