### PR TITLE
Update OSes used for testing

### DIFF
--- a/.ci/coverage.sh
+++ b/.ci/coverage.sh
@@ -6,6 +6,7 @@ set -e -v
 # cpp-coveralls doesn't deal with well. lcov handles it better, but ends up
 # writing two separate records for each file, which again confuses
 # cpp-coveralls (it doesn't merge them). However, if we ask lcov to
-# merge the single file it will do merging.
-lcov -c -d . --include "$PWD/include/spead2/*" --include "$PWD/src/*" -o lcov-temp.info
+# merge the single file it will do merging. We still need --ignore-errors since
+# lcov 2.0 because it gets mismatches on the end line for functions.
+lcov -c -d . --include "$PWD/include/spead2/*" --include "$PWD/src/*" --ignore-errors mismatch -o lcov-temp.info
 lcov -a lcov-temp.info -o lcov.info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
             cxx: clang++-11
           - os: ubuntu-24.04
             cxx: clang++-18
-          - os: macos-14
+          - os: macos-15
             cxx: clang++
     runs-on: ${{ matrix.os }}
     env:
@@ -33,7 +33,7 @@ jobs:
         run: ./.ci/install-sys-pkgs.sh
       - uses: actions/setup-python@v6
         with:
-          # 3.10 is the minimum version supported on macos-14 builders
+          # 3.10 is the minimum version supported on macos-15 builders
           python-version: '3.10'
           cache: 'pip'
       - name: Install build requirements
@@ -72,7 +72,7 @@ jobs:
             cc: clang-18
             cxx: clang++-18
             python-version: '3.14'
-          - os: macos-14
+          - os: macos-15
             cc: clang
             cxx: clang++
             python-version: '3.14'
@@ -122,7 +122,7 @@ jobs:
       - run: pre-commit run --all-files
 
   coverage:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       SCCACHE_GHA_ENABLED: "true"
     steps:
@@ -248,7 +248,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14]
+        os: [macos-15]
         python: [cp39, cp310, cp311, cp312, cp313, cp314]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
- Upgrade coverage to use Ubuntu 24.04. That pulls in lcov 2.0, which is much fussier and complains about a lot of mismatches (which are most likely due to the Python and C++ builds being built differently), so I've had to add `--ignore-errors`.
- Upgrade MacOS to macos-15, since the macos-14 runner is deprecated.